### PR TITLE
hotfix/featured-clinics-caching > master

### DIFF
--- a/docroot/themes/custom/uwmbase/components/clinic-page/clinic-page-tabs.js
+++ b/docroot/themes/custom/uwmbase/components/clinic-page/clinic-page-tabs.js
@@ -1,6 +1,8 @@
 /**
  * @file
  * Additional functionality for Bootstrap nav tabs on Clinic pages.
+ *
+ * @TODO not currently in use. See uwmbase/nav-tabs library.
  */
 
 (function ($, Drupal, drupalSettings) {

--- a/docroot/themes/custom/uwmbase/uwmbase.libraries.yml
+++ b/docroot/themes/custom/uwmbase/uwmbase.libraries.yml
@@ -129,7 +129,7 @@ clinic-page:
   css:
     component:
       dist/css/clinic-page.css: {}
-  js:
+#  js:
 #    dist/js/clinic-page-tabs.js: {}
   dependencies:
     - uwmbase/clinic-hours
@@ -139,7 +139,6 @@ clinic-page:
 clinic-hours:
   js:
     dist/js/clinic-page-hours.js: {}
-  #    dist/js/clinic-page-tabs.js: {}
   dependencies:
   - uwmbase/momentjs
   - uwmbase/clockwise-wait-times

--- a/docroot/themes/custom/uwmbase/uwmbase.theme
+++ b/docroot/themes/custom/uwmbase/uwmbase.theme
@@ -262,6 +262,18 @@ function uwmbase_preprocess_node(&$variables, $hook) {
 
   $variables['display_context'] = $displayContext;
 
+  // Clinic and provider cards have some elements conditionally displayed based
+  // on the context in which they're rendered. Ensure cards are not cached
+  // across different usages.
+  if (in_array($variables['view_mode'], [
+    'card',
+    'card_brief',
+    'provider_card',
+    'location_card',
+  ])) {
+    $variables['#cache']['contexts'][] = 'url.path';
+  }
+
   // Restore simple node container classes:
   // @TODO: Where did these go?
   $variables['attributes'] = $variables['attributes'] ?? [];
@@ -502,10 +514,6 @@ function uwmbase_preprocess_node(&$variables, $hook) {
 
     $variables['#attached']['library'][] = 'uwmbase/homepage';
 
-  }
-
-  if ($variables['view_mode'] == 'provider_card') {
-    $variables['#cache']['contexts'][] = 'url.path';
   }
 
 }


### PR DESCRIPTION
https://www.wrike.com/open.htm?id=368713230

This resolves the issue of clinic cards being cached across location search results and featured clinics, i.e. showing the wrong card version on one or the other.