### PR TITLE
maintenance/prod-configuration-sync > master (3)

### DIFF
--- a/config/envs/dev/stevie/devel.settings.yml
+++ b/config/envs/dev/stevie/devel.settings.yml
@@ -1,0 +1,6 @@
+page_alter: false
+raw_names: false
+error_handlers:
+  1: 1
+rebuild_theme: false
+devel_dumper: var_dumper

--- a/config/envs/local/stevie/devel.settings.yml
+++ b/config/envs/local/stevie/devel.settings.yml
@@ -1,0 +1,6 @@
+page_alter: false
+raw_names: false
+error_handlers:
+  1: 1
+rebuild_theme: false
+devel_dumper: var_dumper


### PR DESCRIPTION
Add the `devel.settings` config to the `local` and `dev` environment splits, where the devel module is enabled