### PR TITLE
maintenance/admin-region > stage

### DIFF
--- a/config/stevie/block.block.uwmbase_local_actions.yml
+++ b/config/stevie/block.block.uwmbase_local_actions.yml
@@ -8,8 +8,8 @@ _core:
   default_config_hash: SoECx-tfiCrMPw4wg7drv8aGNsG82qei8xV0vepi8NI
 id: uwmbase_local_actions
 theme: uwmbase
-region: content
-weight: -4
+region: admin
+weight: -5
 provider: null
 plugin: local_actions_block
 settings:

--- a/config/stevie/block.block.uwmbase_local_tasks.yml
+++ b/config/stevie/block.block.uwmbase_local_tasks.yml
@@ -8,8 +8,8 @@ _core:
   default_config_hash: H0SmmLbfr6Gr0PaWIFiLq_sC6ZDVsB6Wd59fX5WUEII
 id: uwmbase_local_tasks
 theme: uwmbase
-region: content
-weight: -5
+region: admin
+weight: -6
 provider: null
 plugin: local_tasks_block
 settings:

--- a/docroot/themes/custom/uwmbase/components/layouts/layout-sections/layout-sections--no-cols.twig
+++ b/docroot/themes/custom/uwmbase/components/layouts/layout-sections/layout-sections--no-cols.twig
@@ -31,6 +31,18 @@
         {% endblock %}
       {% endif %}
 
+      {# Admin (local tasks and actions) #}
+      {% set page_admin = page.admin|render %}
+      {% if page_admin|striptags|trim %}
+        {% block admin %}
+          <div class="row">
+            <div class="col-sm-12">
+              {{ page_admin }}
+            </div>
+          </div>
+        {% endblock %}
+      {% endif %}
+
       {# Breadcrumb #}
       {% if page.breadcrumb %}
         {% block breadcrumb %}

--- a/docroot/themes/custom/uwmbase/components/layouts/layout-sections/layout-sections.twig
+++ b/docroot/themes/custom/uwmbase/components/layouts/layout-sections/layout-sections.twig
@@ -31,6 +31,7 @@
  * - page.header: Items for the header region.
  * - page.primary_menu: Items for the primary menu region.
  * - page.secondary_menu: Items for the secondary menu region.
+ * - page.admin: Items for the admin region.
  * - page.highlighted: Items for the highlighted content region.
  * - page.breadcrumb: Items for the breadcrumb region.
  * - page.title: Items for the title region.
@@ -72,6 +73,16 @@
             {% block header %}
               <div class="col-sm-12">
                 {{ page.header }}
+              </div>
+            {% endblock %}
+          {% endif %}
+
+          {# Admin (local tasks and actions) #}
+          {% set page_admin = page.admin|render %}
+          {% if page_admin|striptags|trim %}
+            {% block admin %}
+              <div class="col-sm-12">
+                {{ page_admin }}
               </div>
             {% endblock %}
           {% endif %}

--- a/docroot/themes/custom/uwmbase/src/scss/_administrator-elements.scss
+++ b/docroot/themes/custom/uwmbase/src/scss/_administrator-elements.scss
@@ -14,7 +14,8 @@ body.adminimal-admin-toolbar.user-role-authenticated {
   }
 
 
-  pre {
+  // Style <pre> if not Symfony var-dumper (which has its own coloring)
+  pre:not(.sf-dump) {
     background: #f4f4f4;
     border: 1px solid #ddd;
     border-left: 3px solid #f36d33;

--- a/docroot/themes/custom/uwmbase/templates/layout/page--media--uwm-provider-resource-document.html.twig
+++ b/docroot/themes/custom/uwmbase/templates/layout/page--media--uwm-provider-resource-document.html.twig
@@ -1,9 +1,7 @@
-
-        {#
+{#
 /**
  * @file
- * Theme override to display a template which uses the sections field to display
- * components on a page.
+ * Theme override to display a Provider Resource Document media entity page.
  *
  * The doctype, html, head and body tags are not in this template. Instead they
  * can be found in the html.html.twig template in this directory.
@@ -32,6 +30,7 @@
  * - page.header: Items for the header region.
  * - page.primary_menu: Items for the primary menu region.
  * - page.secondary_menu: Items for the secondary menu region.
+ * - page.admin: Items for the admin region.
  * - page.highlighted: Items for the highlighted content region.
  * - page.breadcrumb: Items for the breadcrumb region.
  * - page.title: Items for the title region.
@@ -49,10 +48,20 @@
 
 {{ attach_library('uwmbase/provider-resource-media') }}
 
-
-  {# Main #}
+{# Main #}
 {% block main %}
     <div id="main-container" role="main" {{ attributes.addClass(classes).addClass('uwm-accent-color__teal') }}>
+
+        {# Admin (local tasks and actions) #}
+        {% set page_admin = page.admin|render %}
+        {% if page_admin|striptags|trim %}
+            {% block admin %}
+                <div class="container-xl">
+                    {{ page_admin }}
+                </div>
+            {% endblock %}
+        {% endif %}
+
         {# Help #}
         {% if page.help %}
             {% block help %}
@@ -77,8 +86,7 @@
             </nav>
             {{ page.title }}
         </section>
-       
-        
+
         {# Content #}
         {% block content %}
         <section class="container-xl">

--- a/docroot/themes/custom/uwmbase/templates/layout/page--media--uwm-provider-resource-video.html.twig
+++ b/docroot/themes/custom/uwmbase/templates/layout/page--media--uwm-provider-resource-video.html.twig
@@ -1,9 +1,7 @@
-
-        {#
+{#
 /**
  * @file
- * Theme override to display a template which uses the sections field to display
- * components on a page.
+ * Theme override to display a Provider Resource Video media entity page.
  *
  * The doctype, html, head and body tags are not in this template. Instead they
  * can be found in the html.html.twig template in this directory.
@@ -32,6 +30,7 @@
  * - page.header: Items for the header region.
  * - page.primary_menu: Items for the primary menu region.
  * - page.secondary_menu: Items for the secondary menu region.
+ * - page.admin: Items for the admin region.
  * - page.highlighted: Items for the highlighted content region.
  * - page.breadcrumb: Items for the breadcrumb region.
  * - page.title: Items for the title region.
@@ -50,15 +49,27 @@
 {{ attach_library('uwmbase/provider-resource-media') }}
 
 
-  {# Main #}
+{# Main #}
 {% block main %}
     <div id="main-container" role="main" {{ attributes.addClass(classes).addClass('uwm-accent-color__teal') }}>
+
+        {# Admin (local tasks and actions) #}
+        {% set page_admin = page.admin|render %}
+        {% if page_admin|striptags|trim %}
+            {% block admin %}
+                <div class="container-xl">
+                    {{ page_admin }}
+                </div>
+            {% endblock %}
+        {% endif %}
+
         {# Help #}
         {% if page.help %}
             {% block help %}
                 {{ page.help }}
             {% endblock %}
-        {% endif %}   
+        {% endif %}
+
         <section class="content-header container-xl">
             {# manually output breadcrumbs #}
             {{ attach_library('uwmbase/breadcrumb') }}
@@ -75,7 +86,6 @@
             </nav>
             {{ page.title }}
         </section>
-       
         
         {# Content #}
         {% block content %}

--- a/docroot/themes/custom/uwmbase/templates/layout/page--media.html.twig
+++ b/docroot/themes/custom/uwmbase/templates/layout/page--media.html.twig
@@ -1,9 +1,7 @@
-
-        {#
+{#
 /**
  * @file
- * Theme override to display a template which uses the sections field to display
- * components on a page.
+ * Theme override to display a Media entity by default.
  *
  * The doctype, html, head and body tags are not in this template. Instead they
  * can be found in the html.html.twig template in this directory.
@@ -32,6 +30,7 @@
  * - page.header: Items for the header region.
  * - page.primary_menu: Items for the primary menu region.
  * - page.secondary_menu: Items for the secondary menu region.
+ * - page.admin: Items for the admin region.
  * - page.highlighted: Items for the highlighted content region.
  * - page.breadcrumb: Items for the breadcrumb region.
  * - page.title: Items for the title region.
@@ -47,23 +46,30 @@
  */
 #}
 
-
-  {# Main #}
+{# Main #}
 {% block main %}
     <div id="main-container" role="main" {{ attributes.addClass(classes) }}>
+
+        {# Admin (local tasks and actions) #}
+        {% set page_admin = page.admin|render %}
+        {% if page_admin|striptags|trim %}
+            {% block admin %}
+                <div class="container-xl">
+                    {{ page_admin }}
+                </div>
+            {% endblock %}
+        {% endif %}
+
         {# Help #}
         {% if page.help %}
             {% block help %}
                 {{ page.help }}
             {% endblock %}
         {% endif %}
-
-        
        
-                <section class="content-header container-xl">
-                    {{ page.title }}
-                </section>
-       
+        <section class="content-header container-xl">
+            {{ page.title }}
+        </section>
         
         {# Content #}
         {% block content %}

--- a/docroot/themes/custom/uwmbase/templates/layout/page--node--uwm-basic-page.html.twig
+++ b/docroot/themes/custom/uwmbase/templates/layout/page--node--uwm-basic-page.html.twig
@@ -30,6 +30,7 @@
  * - page.header: Items for the header region.
  * - page.primary_menu: Items for the primary menu region.
  * - page.secondary_menu: Items for the secondary menu region.
+ * - page.admin: Items for the admin region.
  * - page.highlighted: Items for the highlighted content region.
  * - page.breadcrumb: Items for the breadcrumb region.
  * - page.title: Items for the title region.
@@ -58,6 +59,17 @@
 {# Main #}
 {% block main %}
     <div id="main-container" role="main" {{ attributes.addClass(classes) }}>
+
+        {# Admin (local tasks and actions) #}
+        {% set page_admin = page.admin|render %}
+        {% if page_admin|striptags|trim %}
+            {% block admin %}
+                <div class="container-xl">
+                    {{ page_admin }}
+                </div>
+            {% endblock %}
+        {% endif %}
+
         {# Help #}
         {% if page.help %}
             {% block help %}

--- a/docroot/themes/custom/uwmbase/templates/layout/page--node--uwm-hub-page.html.twig
+++ b/docroot/themes/custom/uwmbase/templates/layout/page--node--uwm-hub-page.html.twig
@@ -1,9 +1,8 @@
 
-        {#
+{#
 /**
  * @file
- * Theme override to display a template which uses the sections field to display
- * components on a page.
+ * Theme override to display a Hub Page node page.
  *
  * The doctype, html, head and body tags are not in this template. Instead they
  * can be found in the html.html.twig template in this directory.
@@ -32,6 +31,7 @@
  * - page.header: Items for the header region.
  * - page.primary_menu: Items for the primary menu region.
  * - page.secondary_menu: Items for the secondary menu region.
+ * - page.admin: Items for the admin region.
  * - page.highlighted: Items for the highlighted content region.
  * - page.breadcrumb: Items for the breadcrumb region.
  * - page.title: Items for the title region.
@@ -47,8 +47,6 @@
  */
 #}
 
-
-
 {% set accent_color = drupal_field('field_uwm_accent_color', 'node', node.id) %}
 {% set classes = [
     'main-container',
@@ -56,9 +54,21 @@
 ]%}
 
 {% set has_hero = drupal_field('field_uwm_hero', 'node', node.id).0 %}
+
 {# Main #}
 {% block main %}
     <div id="main-container" role="main" {{ attributes.addClass(classes) }}>
+
+        {# Admin (local tasks and actions) #}
+        {% set page_admin = page.admin|render %}
+        {% if page_admin|striptags|trim %}
+            {% block admin %}
+                <div class="container-xl">
+                    {{ page_admin }}
+                </div>
+            {% endblock %}
+        {% endif %}
+
         {# Help #}
         {% if page.help %}
             {% block help %}
@@ -66,7 +76,7 @@
             {% endblock %}
         {% endif %}
 
-                {# Page Top #}
+        {# Page Top #}
         {% block pagetop %}
         {% if page.breadcrumb and not has_hero %}
             {% block content_header %}

--- a/docroot/themes/custom/uwmbase/uwmbase.info.yml
+++ b/docroot/themes/custom/uwmbase/uwmbase.info.yml
@@ -83,6 +83,7 @@ regions:
   header: Header
   primary_menu: Primary menu
   secondary_menu: Secondary menu
+  admin: Admin
   highlighted: Highlighted
   breadcrumb: Breadcrumb
   title: Title


### PR DESCRIPTION
This creates a new region in the uwmbase theme, 'Admin', to contain two administrative (logged-in only) blocks: Drupal tabs and local actions (if any).

The new region is printed on all page templates. The `|render` and `|striptags|trim` ensures that:
* the region and wrappers are printed only if the blocks are non-empty
* rendering runs only once - otherwise, if run twice, Drupal adds auto-increment suffixes to HTML ids

---

PR to master after, after this is confirmed on stage - https://github.com/uwmweb/uwmcms/pull/1052