### PR TITLE
feature/hero-med-services-additional-text-field > master

### DIFF
--- a/config/stevie/core.entity_form_display.paragraph.half_wide_hero.default.yml
+++ b/config/stevie/core.entity_form_display.paragraph.half_wide_hero.default.yml
@@ -7,9 +7,9 @@ dependencies:
     - field.field.paragraph.half_wide_hero.field_bottom_content_blocks
     - field.field.paragraph.half_wide_hero.field_uwm_media
     - field.field.paragraph.half_wide_hero.uwm_text
+    - field.field.paragraph.half_wide_hero.uwm_text_2
     - paragraphs.paragraphs_type.half_wide_hero
   module:
-    - allowed_formats
     - entity_browser
     - paragraphs
     - text
@@ -20,7 +20,7 @@ mode: default
 content:
   field_bottom_content_blocks:
     type: paragraphs
-    weight: 1
+    weight: 2
     settings:
       title: component
       title_plural: components
@@ -39,7 +39,7 @@ content:
     region: content
   field_uwm_media:
     type: entity_browser_entity_reference
-    weight: 2
+    weight: 3
     settings:
       entity_browser: media_browser
       field_widget_display: rendered_entity
@@ -63,6 +63,14 @@ content:
         hide_guidelines: '1'
     type: text_textarea
     region: content
+  uwm_text_2:
+    type: text_textarea
+    weight: 1
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
 hidden:
   created: true
   status: true

--- a/config/stevie/core.entity_view_display.paragraph.half_wide_hero.default.yml
+++ b/config/stevie/core.entity_view_display.paragraph.half_wide_hero.default.yml
@@ -6,6 +6,7 @@ dependencies:
     - field.field.paragraph.half_wide_hero.field_bottom_content_blocks
     - field.field.paragraph.half_wide_hero.field_uwm_media
     - field.field.paragraph.half_wide_hero.uwm_text
+    - field.field.paragraph.half_wide_hero.uwm_text_2
     - paragraphs.paragraphs_type.half_wide_hero
   module:
     - entity_reference_revisions
@@ -17,7 +18,7 @@ mode: default
 content:
   field_bottom_content_blocks:
     type: entity_reference_revisions_entity_view
-    weight: 3
+    weight: 2
     label: hidden
     settings:
       view_mode: default
@@ -25,7 +26,7 @@ content:
     third_party_settings: {  }
     region: content
   field_uwm_media:
-    weight: 4
+    weight: 3
     label: hidden
     settings:
       link: true
@@ -34,10 +35,17 @@ content:
     type: entity_reference_entity_view
     region: content
   uwm_text:
-    weight: 1
+    weight: 0
     label: hidden
     settings: {  }
     third_party_settings: {  }
     type: text_default
     region: content
+  uwm_text_2:
+    type: text_default
+    weight: 1
+    region: content
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
 hidden: {  }

--- a/config/stevie/field.field.paragraph.half_wide_hero.uwm_text_2.yml
+++ b/config/stevie/field.field.paragraph.half_wide_hero.uwm_text_2.yml
@@ -1,0 +1,29 @@
+uuid: c1262eda-839c-4548-9a43-24bf0f771c33
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.uwm_text_2
+    - paragraphs.paragraphs_type.half_wide_hero
+  module:
+    - allowed_formats
+    - text
+third_party_settings:
+  allowed_formats:
+    rich_text: rich_text
+    basic_html: '0'
+    unrestricted: '0'
+    unrestricted_no_wysiwyg: '0'
+    plain_text: '0'
+id: paragraph.half_wide_hero.uwm_text_2
+field_name: uwm_text_2
+entity_type: paragraph
+bundle: half_wide_hero
+label: 'Additional Text'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: text_long

--- a/config/stevie/field.storage.paragraph.uwm_text_2.yml
+++ b/config/stevie/field.storage.paragraph.uwm_text_2.yml
@@ -1,0 +1,21 @@
+uuid: 09c112cc-e903-4699-8db3-581efb4c7d58
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+    - text
+_core:
+  default_config_hash: KweCNxGTbK8H3gua4F5k08Q8dxEuE5xCjXU9KfgF6c4
+id: paragraph.uwm_text_2
+field_name: uwm_text_2
+entity_type: paragraph
+type: text_long
+settings: {  }
+module: text
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false


### PR DESCRIPTION
This adds a rich text field, "Additional Text", to the hero for Med Service pages, to account for the additional text in the hero on Urgent Care and Emergency Medicine pages.

**Note:** This work is also included in the `feature/hero-med-services-styling-368077494` branch. I've created this separate branch in case we want to deploy the fields sooner for content work.
See: 