### PR TITLE
feature/clinic-remove-accent-headers-372572500 > master

### DIFF
--- a/docroot/themes/custom/uwmbase/components/clinic-page/clinic-page.scss
+++ b/docroot/themes/custom/uwmbase/components/clinic-page/clinic-page.scss
@@ -192,10 +192,6 @@
         justify-content: space-between;
         align-items: center;
 
-        &.clinic-page__link-directions {
-          border-top: 1px solid theme-color('border-gray');
-        }
-
         a {
           display: block;
           padding-right: 0.5rem; // 8px
@@ -318,11 +314,6 @@
   .clinic-page__overview {
     background-color: theme-color('background-light-gray');
     padding: 1rem 0 2rem 0;
-
-    .clinic-page__overview-header {
-      margin-top: 0;
-    }
-
   }
 
   .clinic-page__directions-tab {

--- a/docroot/themes/custom/uwmbase/components/clinic-page/clinic-page.scss
+++ b/docroot/themes/custom/uwmbase/components/clinic-page/clinic-page.scss
@@ -308,16 +308,37 @@
 
   .field--name-field-uwm-sections {
     background-color: theme-color('background-light-gray');
+
+    .uwm-section--background-image {
+      min-height: auto;
+    }
+
+    .uwm-section {
+
+      .card-deck {
+        padding-bottom: 0;
+      }
+
+      .card {
+        margin-bottom: 1rem; // 16px
+      }
+
+    }
   }
 
   .clinic-page__overview {
     background-color: theme-color('background-light-gray');
-    padding: 0.875rem 0 2rem 0;
+    padding: 2.125rem 0 2rem 0; // 34px 32px (34px + 16px bottom card = 50px)
 
     .field--name-body {
 
       h2 {
-        padding: 1rem 0 1.875rem 0;
+        padding-bottom: 1.75rem; // 28px
+        margin-bottom: 0;
+
+        &:first-child {
+          padding-top: 0;
+        }
       }
 
     }
@@ -362,6 +383,20 @@
       }
     }
   }
+
+  .field--name-field-uwm-sections-2 {
+    padding-top: 2rem; // 32px
+
+    .uwm-accent-heading__title {
+      margin-top: 0;
+      padding-top: 0;
+    }
+
+    .h2-placeholder {
+      display: none;
+    }
+  }
+
 
   // Mobile/tablet
 

--- a/docroot/themes/custom/uwmbase/components/clinic-page/clinic-page.scss
+++ b/docroot/themes/custom/uwmbase/components/clinic-page/clinic-page.scss
@@ -387,9 +387,14 @@
   .field--name-field-uwm-sections-2 {
     padding-top: 2rem; // 32px
 
-    .uwm-accent-heading__title {
+    h2 {
       margin-top: 0;
       padding-top: 0;
+
+      &:not(.uwm-accent-heading__title) {
+        padding-bottom: 1.75rem; // 28px
+        margin-bottom: 0;
+      }
     }
 
     .h2-placeholder {

--- a/docroot/themes/custom/uwmbase/components/clinic-page/clinic-page.scss
+++ b/docroot/themes/custom/uwmbase/components/clinic-page/clinic-page.scss
@@ -247,10 +247,9 @@
         display: none;
       }
 
-      .leader,
-      .uwm-accent-heading__title  {
+      .leader {
         margin: 0;
-        padding: 1rem 0;
+        padding: 1rem 0 1.75rem 0; // 16px 28px
       }
 
       .field--name-field-uwm-sections .card .card-header {
@@ -313,7 +312,15 @@
 
   .clinic-page__overview {
     background-color: theme-color('background-light-gray');
-    padding: 1rem 0 2rem 0;
+    padding: 0.875rem 0 2rem 0;
+
+    .field--name-body {
+
+      h2 {
+        padding: 1rem 0 1.875rem 0;
+      }
+
+    }
   }
 
   .clinic-page__directions-tab {

--- a/docroot/themes/custom/uwmbase/components/clinic-page/node--res-clinic--full.html.twig
+++ b/docroot/themes/custom/uwmbase/components/clinic-page/node--res-clinic--full.html.twig
@@ -334,7 +334,7 @@
           {% endif %}
          
           <div class="clinic-page__link clinic-page__link-overview">
-            <a href="#main-tab-tab---clinic-overview-jump">{{ is_hospital ? "Hospital Overview"|t : "Overview"|t }}</a>
+            <a href="#main-tab-tab---overview">{{ is_hospital ? "Hospital Overview"|t : "Overview"|t }}</a>
             <i class="fa fa-angle-right" aria-hidden="true"></i>
           </div>
 

--- a/docroot/themes/custom/uwmbase/components/clinic-page/node--res-clinic--full.tabs-body.html.twig
+++ b/docroot/themes/custom/uwmbase/components/clinic-page/node--res-clinic--full.tabs-body.html.twig
@@ -31,8 +31,6 @@
 
     <div class="container-xl">
 
-      <h3 class="uwm-accent-heading uwm-accent-heading__title">Services</h3>
-
       <h2 class="leader">
         {% if content.field_clinic_services_header|render is not empty %}
           {{ content.field_clinic_services_header }}
@@ -81,14 +79,15 @@
   {{ content.field_uwm_sections }}
 {% endif %}
 
+{#
+   Body field
+#}
 {% if content.body.0 is not empty %}
   <section class="clinic-page__overview">
     <div class="container-xl">
 
-      <h3 id="clinic-overview-jump"
-          class="clinic-page__overview-header uwm-accent-heading uwm-accent-heading__title">
-        {{ is_hospital ? "Hospital Overview"|t : "Clinic Overview"|t }}
-      </h3>
+      {# Left sidebar "Overview" link destination #}
+      <a name="overview" id="overview"></a>
 
       {{ content.body }}
 

--- a/docroot/themes/custom/uwmbase/components/clinic-page/node--res-clinic--full.tabs-directions.html.twig
+++ b/docroot/themes/custom/uwmbase/components/clinic-page/node--res-clinic--full.tabs-directions.html.twig
@@ -10,8 +10,6 @@
 {% set map_query = (plain_title ~ ',' ~ plain_address)|url_encode %}
 
 <div class="container-xl">
-    <h3 class="uwm-accent-heading uwm-accent-heading__title">{{ "Directions &amp; Parking"|t }}</h3>
-
     <div class="row">
         <div class="col-xs-12 col-md-7 order-md-2 clinic-directions__map">
             <div class="map">

--- a/docroot/themes/custom/uwmbase/components/clinic-page/node--res-clinic--full.tabs-providers.html.twig
+++ b/docroot/themes/custom/uwmbase/components/clinic-page/node--res-clinic--full.tabs-providers.html.twig
@@ -1,11 +1,8 @@
 {% if content.field_res_providers|render|trim is not empty %}
-
-<div class="container-xl">
-  <h3 class="uwm-accent-heading uwm-accent-heading__title">{{ "Care Providers"|t }}</h3>
-
-  <div class="row">
-    {# @see field--node--field-res-providers--res-clinic.html.twig #}
-    {{ content.field_res_providers }}
+  <div class="container-xl">
+    <div class="row">
+      {# @see field--node--field-res-providers--res-clinic.html.twig #}
+      {{ content.field_res_providers }}
+    </div>
   </div>
-</div>
 {% endif %}

--- a/docroot/themes/custom/uwmbase/components/clinic-page/node--res-clinic--full.tabs.html.twig
+++ b/docroot/themes/custom/uwmbase/components/clinic-page/node--res-clinic--full.tabs.html.twig
@@ -30,20 +30,25 @@
 
 
       {% if content.field_res_providers|render|trim is not empty %}
-      <li class="nav-item {{ hide_providers_css_class }}">
-        <a class="nav-item nav-link" id="providers-tab-tab" data-toggle="tab"
-          href="#providers-tab" role="tab" aria-controls="providers-tab"
-          aria-selected="false"
-          data-tab-history="true"
-          data-tab-history-changer="push"
-          data-tab-history-update-url="true">
-          {{ '<span>Care</span> <span>Providers</span>' }}
-        </a>
-      </li>
+        <li class="nav-item {{ hide_providers_css_class }}">
+
+          {# Left sidebar "Care Providers" link destination #}
+          <a class="nav-item nav-link" id="providers-tab-tab" data-toggle="tab"
+            href="#providers-tab" role="tab" aria-controls="providers-tab"
+            aria-selected="false"
+            data-tab-history="true"
+            data-tab-history-changer="push"
+            data-tab-history-update-url="true">
+            {# Use spans to designate line breaks for smaller screens. #}
+            {{ '<span>Care</span> <span>Providers</span>' }}
+          </a>
+        </li>
       {% endif %}
 
 
       <li class="nav-item">
+
+        {# Left sidebar "Directions" link destination #}
         <a class="nav-item nav-link" id="directions-tab-tab" data-toggle="tab"
           href="#directions-tab" role="tab" aria-controls="directions-tab"
           aria-selected="false"

--- a/docroot/themes/custom/uwmbase/components/navigation/nav-tabs/nav-tabs.scss
+++ b/docroot/themes/custom/uwmbase/components/navigation/nav-tabs/nav-tabs.scss
@@ -66,7 +66,7 @@ nav.uw-navtabs {
 nav.uw-navtabs--blue-accent {
 
   ul.nav-tabs {
-    padding: 1.5rem 0 calc(1.5rem + 14px) 0; // 24px, 24px + height of blue underline on active
+    padding: 1.5rem 0; // 24px
 
     > li.nav-item {
       background-color: transparent;


### PR DESCRIPTION
https://www.wrike.com/open.htm?id=372572500

* Removes clinic page accent headers: Services, Clinic Overview, Care Providers, Directions & Parking
* Connect left side Overview link to an empty anchor tag (instead of the Overview accent header)
* Adjusts spacing around h2s in the page per Emily's review