### PR TITLE
feature/clinic-remove-accent-headers-372572500 > stage

### DIFF
--- a/docroot/themes/custom/uwmbase/components/clinic-page/clinic-page.scss
+++ b/docroot/themes/custom/uwmbase/components/clinic-page/clinic-page.scss
@@ -192,10 +192,6 @@
         justify-content: space-between;
         align-items: center;
 
-        &.clinic-page__link-directions {
-          border-top: 1px solid theme-color('border-gray');
-        }
-
         a {
           display: block;
           padding-right: 0.5rem; // 8px
@@ -318,11 +314,6 @@
   .clinic-page__overview {
     background-color: theme-color('background-light-gray');
     padding: 1rem 0 2rem 0;
-
-    .clinic-page__overview-header {
-      margin-top: 0;
-    }
-
   }
 
   .clinic-page__directions-tab {

--- a/docroot/themes/custom/uwmbase/components/clinic-page/node--res-clinic--full.html.twig
+++ b/docroot/themes/custom/uwmbase/components/clinic-page/node--res-clinic--full.html.twig
@@ -334,7 +334,7 @@
           {% endif %}
          
           <div class="clinic-page__link clinic-page__link-overview">
-            <a href="#main-tab-tab---clinic-overview-jump">{{ is_hospital ? "Hospital Overview"|t : "Overview"|t }}</a>
+            <a href="#main-tab-tab---overview">{{ is_hospital ? "Hospital Overview"|t : "Overview"|t }}</a>
             <i class="fa fa-angle-right" aria-hidden="true"></i>
           </div>
 

--- a/docroot/themes/custom/uwmbase/components/clinic-page/node--res-clinic--full.tabs-body.html.twig
+++ b/docroot/themes/custom/uwmbase/components/clinic-page/node--res-clinic--full.tabs-body.html.twig
@@ -31,8 +31,6 @@
 
     <div class="container-xl">
 
-      <h3 class="uwm-accent-heading uwm-accent-heading__title">Services</h3>
-
       <h2 class="leader">
         {% if content.field_clinic_services_header|render is not empty %}
           {{ content.field_clinic_services_header }}
@@ -81,14 +79,15 @@
   {{ content.field_uwm_sections }}
 {% endif %}
 
+{#
+   Body field
+#}
 {% if content.body.0 is not empty %}
   <section class="clinic-page__overview">
     <div class="container-xl">
 
-      <h3 id="clinic-overview-jump"
-          class="clinic-page__overview-header uwm-accent-heading uwm-accent-heading__title">
-        {{ is_hospital ? "Hospital Overview"|t : "Clinic Overview"|t }}
-      </h3>
+      {# Left sidebar "Overview" link destination #}
+      <a name="overview" id="overview"></a>
 
       {{ content.body }}
 

--- a/docroot/themes/custom/uwmbase/components/clinic-page/node--res-clinic--full.tabs-directions.html.twig
+++ b/docroot/themes/custom/uwmbase/components/clinic-page/node--res-clinic--full.tabs-directions.html.twig
@@ -10,8 +10,6 @@
 {% set map_query = (plain_title ~ ',' ~ plain_address)|url_encode %}
 
 <div class="container-xl">
-    <h3 class="uwm-accent-heading uwm-accent-heading__title">{{ "Directions &amp; Parking"|t }}</h3>
-
     <div class="row">
         <div class="col-xs-12 col-md-7 order-md-2 clinic-directions__map">
             <div class="map">

--- a/docroot/themes/custom/uwmbase/components/clinic-page/node--res-clinic--full.tabs-providers.html.twig
+++ b/docroot/themes/custom/uwmbase/components/clinic-page/node--res-clinic--full.tabs-providers.html.twig
@@ -1,11 +1,8 @@
 {% if content.field_res_providers|render|trim is not empty %}
-
-<div class="container-xl">
-  <h3 class="uwm-accent-heading uwm-accent-heading__title">{{ "Care Providers"|t }}</h3>
-
-  <div class="row">
-    {# @see field--node--field-res-providers--res-clinic.html.twig #}
-    {{ content.field_res_providers }}
+  <div class="container-xl">
+    <div class="row">
+      {# @see field--node--field-res-providers--res-clinic.html.twig #}
+      {{ content.field_res_providers }}
+    </div>
   </div>
-</div>
 {% endif %}

--- a/docroot/themes/custom/uwmbase/components/clinic-page/node--res-clinic--full.tabs.html.twig
+++ b/docroot/themes/custom/uwmbase/components/clinic-page/node--res-clinic--full.tabs.html.twig
@@ -30,20 +30,25 @@
 
 
       {% if content.field_res_providers|render|trim is not empty %}
-      <li class="nav-item {{ hide_providers_css_class }}">
-        <a class="nav-item nav-link" id="providers-tab-tab" data-toggle="tab"
-          href="#providers-tab" role="tab" aria-controls="providers-tab"
-          aria-selected="false"
-          data-tab-history="true"
-          data-tab-history-changer="push"
-          data-tab-history-update-url="true">
-          {{ '<span>Care</span> <span>Providers</span>' }}
-        </a>
-      </li>
+        <li class="nav-item {{ hide_providers_css_class }}">
+
+          {# Left sidebar "Care Providers" link destination #}
+          <a class="nav-item nav-link" id="providers-tab-tab" data-toggle="tab"
+            href="#providers-tab" role="tab" aria-controls="providers-tab"
+            aria-selected="false"
+            data-tab-history="true"
+            data-tab-history-changer="push"
+            data-tab-history-update-url="true">
+            {# Use spans to designate line breaks for smaller screens. #}
+            {{ '<span>Care</span> <span>Providers</span>' }}
+          </a>
+        </li>
       {% endif %}
 
 
       <li class="nav-item">
+
+        {# Left sidebar "Directions" link destination #}
         <a class="nav-item nav-link" id="directions-tab-tab" data-toggle="tab"
           href="#directions-tab" role="tab" aria-controls="directions-tab"
           aria-selected="false"


### PR DESCRIPTION
https://www.wrike.com/open.htm?id=372572500

* Removes clinic page accent headers: Services, Clinic Overview, Care Providers, Directions & Parking
* Connect left side Overview link to an empty anchor tag (instead of the Overview accent header)