### PR TITLE
UWM-BASE: remove font-weight 600 from .btn-cta and button-cta() default

### DIFF
--- a/docroot/themes/custom/uwmbase/src/scss/init/mixins/mixins.scss
+++ b/docroot/themes/custom/uwmbase/src/scss/init/mixins/mixins.scss
@@ -77,7 +77,6 @@
   transition: all 0.45s ease-in;
   height: 40px;
   line-height: 40px;
-  font-weight: 600;
   color: theme-color('text');
   font-family: "Open Sans", Helvetica, Arial, sans-serif;
   font-size: 14px;


### PR DESCRIPTION
This reverts a global change to the cta buttons font-weight, that occurred when moving the styling into a mixin.