### PR TITLE
hotfix/card-ul-padding > master

### DIFF
--- a/docroot/themes/custom/uwmbase/components/card/card.scss
+++ b/docroot/themes/custom/uwmbase/components/card/card.scss
@@ -32,10 +32,6 @@
     padding-top: 0;
     padding-bottom: 0;
 
-    ul, ol {
-      padding-left: 1.625rem; // 26px
-    }
-
     .list-group-item {
       padding: 0;
       margin: 0;
@@ -204,6 +200,11 @@
     }
 
     .card-body {
+
+      // Align bullets below middle of heart icon.
+      ul, ol {
+        padding-left: 1.625rem; // 26px
+      }
 
       p:last-child,
       ul:last-child,


### PR DESCRIPTION
UWM-BASE: move .card-body ul/ol padding to be specific to .specialty-intro-cards, not all cards