### PR TITLE
hotfix/travis-builds > master (skip BLT front end tests command)

### DIFF
--- a/blt/blt.yml
+++ b/blt/blt.yml
@@ -48,6 +48,8 @@ disable-targets:
     security:
       check:
         updates: true
+    frontend:
+      run: true
 validate:
   twig:
     filesets: {  }

--- a/blt/ci.blt.yml
+++ b/blt/ci.blt.yml
@@ -8,4 +8,4 @@ setup.strategy: sync
 tests.run-server: true
 # The local.hostname must be set to 127.0.0.1:8888 because we are using drush runserver to test the site.
 project.local.hostname: 127.0.0.1:8888
-drush.debug: false
+drush.debug: true

--- a/blt/ci.blt.yml
+++ b/blt/ci.blt.yml
@@ -8,4 +8,4 @@ setup.strategy: sync
 tests.run-server: true
 # The local.hostname must be set to 127.0.0.1:8888 because we are using drush runserver to test the site.
 project.local.hostname: 127.0.0.1:8888
-drush.debug: true
+drush.debug: false


### PR DESCRIPTION
https://www.wrike.com/open.htm?id=380797549

Configure blt to **not** run `tests:frontend:run` command in builds. It was triggering starting the php internal server, which was timing out/erroring strangely. But we don't have any front-end tests, so the build step is unnecessary.