### PR TITLE
feature/finalize-service-specialty-pages > stage (2)

### DIFF
--- a/docroot/themes/custom/uwmbase/components/card/card.scss
+++ b/docroot/themes/custom/uwmbase/components/card/card.scss
@@ -1,5 +1,6 @@
 /**
- * Card content components, based on Bootstrap Cards
+ * Card content components (paragraphs), based on Bootstrap Cards. Most often,
+ * Cards are placed within Grids.
  * - Card paragraph type
  * - Card content block type (referenced in Reusable Content paragraph type)
  *
@@ -8,12 +9,25 @@
  * @see field--field-uwm-card-header.html.twig
  * @see field--field-uwm-card-content.html.twig
  * @see https://getbootstrap.com/docs/4.0/components/card/
+ * @see paragraph--uwm-grid.html.twig
  */
 
 @import 'init';
 
-.field--name-field-uwm-component .card-deck {
+.uwm-grid__cards {
   padding-bottom: 2em;
+
+  .uwm-grid__card {
+    margin-bottom: 1rem;
+
+    .card {
+      // The .col-* wrappers have equal height (as flex children of .row);
+      // set .card to inherit that (equal) height and ensure alignment of card
+      // header / body / footer flex-column children.
+      height: 100%;
+    }
+  }
+
 }
 
 .card {
@@ -60,32 +74,6 @@
     padding-right: $card-spacer-x;
   }
 
-}
-
-@include media-breakpoint-between('sm', 'md') {
-
-  // Between sm and lg breakpoints, cards are structured at 2 per row via a
-  // divider in the markup. Within a card-deck row, cards evenly fill the row,
-  // so rows of 1 are full-width cards. If there is an odd number of cards,
-  // ensure the last one matches the 50% width of the others.
-  // @see paragraph--uwm-grid.html.twig
-  .card-deck .card {
-    flex-basis: calc(50% - (2 * #{$card-deck-margin}));
-    flex-grow: 0;
-  }
-
-  .uwm-grid-column-dividers .card-deck .card {
-    flex-basis: 50%;
-    // IE 11 needs this...
-    max-width: 50%;
-  }
-
-}
-
-@include media-breakpoint-up('sm') {
-  .card-deck .card {
-    margin-bottom: $card-deck-margin;
-  }
 }
 
 // Reusable Content component styled as card, containing a webform
@@ -149,6 +137,11 @@
 // Customize cards in a grid that has column dividers.
 .uwm-grid-column-dividers {
 
+  .card {
+    box-shadow: none;
+    background: transparent;
+  }
+
   .field--name-field-uwm-card-header {
     padding: 0;
     h3 {
@@ -172,14 +165,14 @@
   }
 }
 
-// Row of 3 intro cards on Medical Service/Specialty nodes.
-// This uses a custom css class added via field on Section (or Sections for
-// Medical Services) paragraph.
+// Row of intro cards on Medical Service/Specialty nodes.
+// This uses a custom css class added via field on Sections for
+// Medical Services paragraph.
 // @TODO: move this to medical-services.scss -OR- could this be generalized for
 // h3 in the card header? new text-with-icon paragraph type?
 .uwm-section.specialty-intro-cards {
 
-  .card-deck {
+  .uwm-grid__cards {
     padding-bottom: 0;
   }
 
@@ -217,24 +210,6 @@
     a.btn-cta {
       margin-top: 1.25rem; // 20px
       margin-bottom: 0;
-    }
-
-  }
-
-  @include media-breakpoint-up('md') {
-
-    // Override card-deck default of all cards in single row to enforce
-    // 3 per row.
-    .card {
-      @include make-col(4);
-    }
-
-    .uwm-grid-column-dividers .card-deck > .card {
-      border-left: 1px solid theme-color('border-gray');
-
-      &:nth-of-type(3n+1) {
-        border-left: none;
-      }
     }
 
   }

--- a/docroot/themes/custom/uwmbase/components/card/card.scss
+++ b/docroot/themes/custom/uwmbase/components/card/card.scss
@@ -166,8 +166,8 @@
 }
 
 // Row of intro cards on Medical Service/Specialty nodes.
-// This uses a custom css class added via field on Sections for
-// Medical Services paragraph.
+// This custom css class is added via field on Sections for Medical Services
+// paragraph.
 // @TODO: move this to medical-services.scss -OR- could this be generalized for
 // h3 in the card header? new text-with-icon paragraph type?
 .uwm-section.specialty-intro-cards {

--- a/docroot/themes/custom/uwmbase/components/clinic-page/clinic-page.scss
+++ b/docroot/themes/custom/uwmbase/components/clinic-page/clinic-page.scss
@@ -315,7 +315,7 @@
 
     .uwm-section {
 
-      .card-deck {
+      .uwm-grid__cards {
         padding-bottom: 0;
       }
 

--- a/docroot/themes/custom/uwmbase/components/grid-paragraph/grid-paragraph.scss
+++ b/docroot/themes/custom/uwmbase/components/grid-paragraph/grid-paragraph.scss
@@ -3,34 +3,50 @@
 // Customize first-level paragraphs in a grid that has column dividers.
 .uwm-grid-column-dividers {
 
-  .card-deck > .paragraph,
-  .row > .paragraph {
-    box-shadow: none;
+  .uwm-grid__item,
+  .uwm-grid__card {
     margin: 0 0 2rem 0;
-    padding: 0;
-    background: transparent;
 
     // Add a divider between columns.
+    // 576px+
+    // 2 per row
     @include media-breakpoint-up('sm') {
-      border-left: 1px solid theme-color('border-gray');
-      padding-left: 15px;
-      padding-right: 15px;
+      @include bordered-grid-items(2);
     }
 
-    @include media-breakpoint-between('sm', 'md') {
-      // Between sm-lg, cards are 2-per-row.
-      &:nth-of-type(2n+1) {
-        border-left: none;
+    // 768px+
+    // May be 3 per row
+    @include media-breakpoint-up('md') {
+      &.col-md-4 {
+        @include bordered-grid-items(3);
       }
     }
 
+    // 992px+
+    // Handle 3, 4, 6 per row
     @include media-breakpoint-up('lg') {
-      // At lg+, by default all cards are in one row.
-      // (Hopefully we'll change this to apply the field in which the editor can
-      // choose how many per row; that requires refactoring to not use the
-      // Bootstrap .card-deck wrapper.)
-      &:first-of-type {
-        border-left: none;
+      &.col-lg-4 {
+        @include bordered-grid-items(3);
+      }
+      &.col-lg-3 {
+        @include bordered-grid-items(4);
+      }
+      &.col-lg-2 {
+        @include bordered-grid-items(6);
+      }
+    }
+
+    // 1200px+
+    // Handle 3, 4, 6 per row
+    @include media-breakpoint-up('xl') {
+      &.col-xl-4 {
+        @include bordered-grid-items(3);
+      }
+      &.col-xl-3 {
+        @include bordered-grid-items(4);
+      }
+      &.col-xl-2 {
+        @include bordered-grid-items(6);
       }
     }
 

--- a/docroot/themes/custom/uwmbase/components/view-medical-specialties-for-services/view-medical-specialties-for-services.scss
+++ b/docroot/themes/custom/uwmbase/components/view-medical-specialties-for-services/view-medical-specialties-for-services.scss
@@ -57,52 +57,32 @@
 // 576+
 // 2 per row
 @include media-breakpoint-up('sm'){
-  .medical-specialty-view {
 
-    .views-row {
-      border-right: 1px solid theme-color('border-gray');
-
-      &:nth-child(even),
-      &:last-child {
-        border-right: none;
-      }
-    }
-
+  .medical-specialty-view .views-row {
+    @include bordered-grid-items(2);
   }
+
 }
 
 // 768px+
-// 3 per row (standard)
-// If 2 or 4 total - stay at 2 per row
+// Change to 3 per row (standard)
+// (If 2 or 4 total - stay at 2 per row)
 @include media-breakpoint-up('md') {
-  .medical-specialty-view {
 
-    .views-row.col-md-4 {
-      border-right: 1px solid theme-color('border-gray');
-
-      &:nth-child(3n),
-      &:last-child {
-        border-right: none;
-      }
-    }
-
+  .medical-specialty-view .views-row.col-md-4 {
+    @include bordered-grid-items(3);
   }
+
 }
 
 // 992px+
 // 3 per row (standard)
-// Stay at 2 per row - if 2 or 4 total
+// (If 2 total - stay at 2 per row)
+// If 4 total - change to 4 per row
 @include media-breakpoint-up('lg') {
-  .medical-specialty-view {
 
-    .views-row.col-lg-3 {
-      border-right: 1px solid theme-color('border-gray');
-
-      &:nth-child(4n),
-      &:last-child {
-        border-right: none;
-      }
-    }
-
+  .medical-specialty-view .views-row.col-lg-3 {
+    @include bordered-grid-items(4);
   }
+
 }

--- a/docroot/themes/custom/uwmbase/components/view-medical-specialties-for-services/view-medical-specialties-for-services.scss
+++ b/docroot/themes/custom/uwmbase/components/view-medical-specialties-for-services/view-medical-specialties-for-services.scss
@@ -50,39 +50,32 @@
       margin-top: 1.25rem; // 20px
       margin-bottom: 0;
     }
-  }
 
-}
+    // 576+
+    // 2 per row
+    @include media-breakpoint-up('sm'){
+      @include bordered-grid-items(2);
+    }
 
-// 576+
-// 2 per row
-@include media-breakpoint-up('sm'){
+    // 768px+
+    // Change to 3 per row (standard)
+    // (If 2 or 4 total - stay at 2 per row)
+    @include media-breakpoint-up('md') {
+      &.col-md-4 {
+        @include bordered-grid-items(3);
+      }
+    }
 
-  .medical-specialty-view .views-row {
-    @include bordered-grid-items(2);
-  }
+    // 992px+
+    // 3 per row (standard)
+    // (If 2 total - stay at 2 per row)
+    // If 4 total - change to 4 per row
+    @include media-breakpoint-up('lg') {
+      &.col-lg-3 {
+        @include bordered-grid-items(4);
+      }
+    }
 
-}
-
-// 768px+
-// Change to 3 per row (standard)
-// (If 2 or 4 total - stay at 2 per row)
-@include media-breakpoint-up('md') {
-
-  .medical-specialty-view .views-row.col-md-4 {
-    @include bordered-grid-items(3);
-  }
-
-}
-
-// 992px+
-// 3 per row (standard)
-// (If 2 total - stay at 2 per row)
-// If 4 total - change to 4 per row
-@include media-breakpoint-up('lg') {
-
-  .medical-specialty-view .views-row.col-lg-3 {
-    @include bordered-grid-items(4);
   }
 
 }

--- a/docroot/themes/custom/uwmbase/components/view-medical-specialties-for-services/view-medical-specialties-for-services.scss
+++ b/docroot/themes/custom/uwmbase/components/view-medical-specialties-for-services/view-medical-specialties-for-services.scss
@@ -54,32 +54,55 @@
 
 }
 
-@include media-breakpoint-only('sm'){
+// 576+
+// 2 per row
+@include media-breakpoint-up('sm'){
   .medical-specialty-view {
 
-    .views-row:nth-child(odd) {
+    .views-row {
       border-right: 1px solid theme-color('border-gray');
-    }
 
-    .views-row:last-child {
-      border-right: none;
+      &:nth-child(even),
+      &:last-child {
+        border-right: none;
+      }
     }
 
   }
 }
 
+// 768px+
+// 3 per row (standard)
+// If 2 or 4 total - stay at 2 per row
 @include media-breakpoint-up('md') {
   .medical-specialty-view {
 
-    .views-row {
+    .views-row.col-md-4 {
       border-right: 1px solid theme-color('border-gray');
-    }
 
-    .views-row:nth-child(3n),
-    .views-row:last-child {
+      &:nth-child(3n),
+      &:last-child {
         border-right: none;
+      }
     }
 
   }
+}
 
+// 992px+
+// 3 per row (standard)
+// Stay at 2 per row - if 2 or 4 total
+@include media-breakpoint-up('lg') {
+  .medical-specialty-view {
+
+    .views-row.col-lg-3 {
+      border-right: 1px solid theme-color('border-gray');
+
+      &:nth-child(4n),
+      &:last-child {
+        border-right: none;
+      }
+    }
+
+  }
 }

--- a/docroot/themes/custom/uwmbase/src/scss/base/_sections.scss
+++ b/docroot/themes/custom/uwmbase/src/scss/base/_sections.scss
@@ -11,11 +11,15 @@
 
   &.uwm-section--background-gray {
     background-color: $gray-100;
-    margin-top: 3.125rem;
+    margin-top: 3.125rem; // 50px
 
     // Ensure equal top & bottom padding on a grey section - remove top/bottom
-    // space on first and last child elements that may have their own.
+    // space on first- and last-child elements that may have their own.
     padding: 2rem 0;
+
+    .h2-placeholder {
+      display: none;
+    }
 
     h2.field--name-field-uwm-section-heading:first-child {
       margin-top: 0;
@@ -23,10 +27,13 @@
     }
 
     .field--name-field-uwm-component > .field__item:last-child {
-      p:last-child, ul:last-child, ol:last-child {
+
+      p:last-child, ul:last-child, ol:last-child,
+      .uwm-grid__cards:last-child {
         margin-bottom: 0;
         padding-bottom: 0;
       }
+
     }
   }
 

--- a/docroot/themes/custom/uwmbase/src/scss/init/mixins/mixins.scss
+++ b/docroot/themes/custom/uwmbase/src/scss/init/mixins/mixins.scss
@@ -196,9 +196,8 @@
 // Apply vertical border lines between grid items in a row (e.g. cards),
 // according to how many items are in each row.
 // Apply this mixin to each item, e.g. `.card` or `.views-row`.
-// Pass $per-row as null if the number of items per row is variable -
-// particularly, a .card-deck wrapper by default has all child cards in one row,
-// rather than a fixed number per row.
+// Pass $per-row as null if the number of items per row is unknown - in that
+// case, only the last item is set to not have the right border.
 @mixin bordered-grid-items($per-row: null, $color: theme-color('border-gray')) {
 
   border-right: 1px solid $color;

--- a/docroot/themes/custom/uwmbase/src/scss/init/mixins/mixins.scss
+++ b/docroot/themes/custom/uwmbase/src/scss/init/mixins/mixins.scss
@@ -144,8 +144,6 @@
 
 }
 
-
-
 @mixin button-cta-angled-edge($color: "") {
 
   @if $color == "" {
@@ -191,6 +189,21 @@
     background-color: #21509C;
     color: white;
     text-decoration: none;
+  }
+
+}
+
+// Apply vertical border lines between grid items in a row (e.g. cards),
+// according to how many items are in each row.
+// Apply this mixin to each item, e.g. `.card` or `.views-row`.
+@mixin bordered-grid-items($per-row, $color: theme-color('border-gray')) {
+
+  border-right: 1px solid $color;
+
+  // No border on last item in the row and last item overall.
+  &:nth-child(#{$per-row}n),
+  &:last-child {
+    border-right: none;
   }
 
 }

--- a/docroot/themes/custom/uwmbase/src/scss/init/mixins/mixins.scss
+++ b/docroot/themes/custom/uwmbase/src/scss/init/mixins/mixins.scss
@@ -196,12 +196,21 @@
 // Apply vertical border lines between grid items in a row (e.g. cards),
 // according to how many items are in each row.
 // Apply this mixin to each item, e.g. `.card` or `.views-row`.
-@mixin bordered-grid-items($per-row, $color: theme-color('border-gray')) {
+// Pass $per-row as null if the number of items per row is variable -
+// particularly, a .card-deck wrapper by default has all child cards in one row,
+// rather than a fixed number per row.
+@mixin bordered-grid-items($per-row: null, $color: theme-color('border-gray')) {
 
   border-right: 1px solid $color;
 
-  // No border on last item in the row and last item overall.
-  &:nth-child(#{$per-row}n),
+  // No border on the last item in each row.
+  @if ($per-row) {
+    &:nth-child(#{$per-row}n) {
+      border-right: none;
+    }
+  }
+
+  // No border on the last item overall.
   &:last-child {
     border-right: none;
   }

--- a/docroot/themes/custom/uwmbase/templates/paragraphs/paragraph--uwm-grid.html.twig
+++ b/docroot/themes/custom/uwmbase/templates/paragraphs/paragraph--uwm-grid.html.twig
@@ -11,6 +11,7 @@
  * - add_container: boolean, whether to add Bootstrap grid container wrapper
  *   (via usual `.container-xl`). This is a fallback only if the Grid is not
  *   within a Section or Sections for Medical Services parent paragraph.
+ * - field_uwm_columns_per_row: integer; value extracted from this field.
  *
  * @see template_preprocess_paragraph()
  * @see uwmbase_preprocess_paragraph__uwm_grid()
@@ -32,39 +33,64 @@
   ]
 %}
 
-{% if content.field_uwm_columns_per_row %}
-  {% set number_columns = content.field_uwm_columns_per_row['#items'].getString() %}
-  {% set grid_classes = "col-lg-" ~ 12 / number_columns ~ " col-sm-6" %}
-{% endif %}
-
 {#
-  TODO: Bootstrap card deck places all cards in a single row, regardless of how
-  many there are. Refactor so the cards case does not use the card deck, but the
-  same logic as the general case - enabling the content author's choice in the
-  "Number of columns" field to apply.
-  This should be fairly minor styling changes; the key is to audit all existing
-  content uses of Grids containing Cards to ensure the styling does not break
-  and that the desired "Number of columns" is actually set.
+  Retrieve the desired number of items per row from field.
 
-  There is a backlog task:
+  Note: previously, if items were cards, the Bootstrap "card deck" wrapper was
+  used to place however many items there were into a single row. Thus this
+  field value was ignored, and the content may have incorrect values in it.
+  For the cards case now, automatically set a reasonable number of cards per
+  row (including responsive handling) based on total number of cards.
   @see https://www.wrike.com/open.htm?id=354924642
 #}
-{% if style_as_cards %}
-  <div {{ attributes.addClass(classes) }}>
-    <div class="card-deck">
-      {% for key, item in content.field_uwm_columns if key|first != '#' %}
-        {{ item }}
-      {% endfor %}
-    </div>
-  </div>
-{% else %}
-  <div {{ attributes.addClass(classes) }}>
-    <div class="row">
-      {% for key, item in content.field_uwm_columns if key|first != '#' %}
-        <div class="uwm-grid__item {{ grid_classes }}">
-          {{ item }}
-        </div>
-      {% endfor %}
-    </div>
-  </div>
+{% if field_uwm_columns_per_row is not empty %}
+  {% set grid_classes = 'col-sm-6 col-lg-' ~ 12 / field_uwm_columns_per_row %}
 {% endif %}
+
+{% if style_as_cards %}
+
+  {# 2 items = 2 per row #}
+  {% if total_grid_items == 2 %}
+    {% set grid_classes = 'col-sm-6' %}
+
+  {# 4 items = 2 per row, @ lg+ 4 per row #}
+  {% elseif total_grid_items == 4 %}
+    {% set grid_classes = 'col-sm-6 col-lg-3' %}
+
+  {# 3 or 5+ items #}
+  {% elseif (total_grid_items == 3 or total_grid_items > 4) %}
+
+    {#
+      Dividers styling:
+      If there are only vertical borders between items, not full card styling,
+      the card content has a bit more width, so we fit 3 @ 768px+
+      2 per row, @ md+ 3 per row
+    #}
+    {% if use_column_dividers %}
+      {% set grid_classes = 'col-sm-6 col-md-4' %}
+
+    {#
+      Normal card styling:
+      Card content is narrower because cards have both space between them and
+      side padding within each one - so we fit 3 @ 992px+
+      2 per row, @ lg+ 3 per row
+    #}
+    {% else %}
+      {% set grid_classes = 'col-sm-6 col-lg-4' %}
+
+    {% endif %}
+
+  {% endif %}
+
+{% endif %}
+
+
+<div {{ attributes.addClass(classes) }}>
+  <div class="{{ style_as_cards ? 'uwm-grid__cards' : 'uwm-grid__items' }} row">
+    {% for key, item in content.field_uwm_columns if key|first != '#' %}
+      <div class="{{ style_as_cards ? 'uwm-grid__card' : 'uwm-grid__item' }} {{ grid_classes }}">
+        {{ item }}
+      </div>
+    {% endfor %}
+  </div>
+</div>

--- a/docroot/themes/custom/uwmbase/templates/views/views-view-unformatted--uwm-medical-specialties-for-service--block-1.html.twig
+++ b/docroot/themes/custom/uwmbase/templates/views/views-view-unformatted--uwm-medical-specialties-for-service--block-1.html.twig
@@ -21,10 +21,13 @@
 {% endif %}
 
 {#
-  Set Bootstrap cols based on total # of items:
+  Set number of items per row and responsive handling based on total # of items:
   2 items = 2 per row
   4 items = 2 per row, @ lg+ 4 per row
   3 or 5+ items = 2 per row, @ md+ 3 per row
+
+  Note: this matches handling for Grid with Cards and dividers styling/
+  @see paragraph--uwm-grid.html.twig
 #}
 {% for row in rows %}
   {%

--- a/docroot/themes/custom/uwmbase/templates/views/views-view-unformatted--uwm-medical-specialties-for-service--block-1.html.twig
+++ b/docroot/themes/custom/uwmbase/templates/views/views-view-unformatted--uwm-medical-specialties-for-service--block-1.html.twig
@@ -21,14 +21,18 @@
 {% endif %}
 
 {#
-  Set Bootstrap cols based on whether there are just 2 items (2 per row), or
-  more than 2 (3 per row).
+  Set Bootstrap cols based on total # of items:
+  2 items = 2 per row
+  4 items = 2 per row, @ lg+ 4 per row
+  3 or 5+ items = 2 per row, @ md+ 3 per row
 #}
 {% for row in rows %}
   {%
     set row_classes = [
       default_row_class ? 'views-row',
-      view.total_rows > 2 ? 'col-sm-6 col-md-4' : 'col-sm-6',
+      view.total_rows == 2 ? 'col-sm-6',
+      view.total_rows == 4 ? 'col-sm-6 col-lg-3',
+      (view.total_rows == 3 or view.total_rows > 4) ? 'col-sm-6 col-md-4'
     ]
   %}
   <div{{ row.attributes.addClass(row_classes) }}>

--- a/docroot/themes/custom/uwmbase/uwmbase.theme
+++ b/docroot/themes/custom/uwmbase/uwmbase.theme
@@ -1175,13 +1175,29 @@ function uwmbase_preprocess_paragraph__uwm_grid(&$variables) {
   /** @var \Drupal\paragraphs\ParagraphInterface $grid_paragraph */
   $grid_paragraph = $variables['paragraph'];
 
+  /** @var \Drupal\paragraphs\ParagraphInterface[] $col_paragraphs */
+  $col_paragraphs = [];
+  if (!$grid_paragraph->get('field_uwm_columns')->isEmpty()) {
+    $col_paragraphs = $grid_paragraph->get('field_uwm_columns')->referencedEntities();
+  }
+
+  $variables['total_grid_items'] = count($col_paragraphs);
+
+  // Check field for desired number of items per row.
+  // NOTE: This setting is NOT currently used for cards case.
+  // @see paragraph--uwm-grid.html.twig
+  $variables['field_uwm_columns_per_row'] = NULL;
+  if ($grid_paragraph->hasField('field_uwm_columns_per_row') && !$grid_paragraph->get('field_uwm_columns_per_row')->isEmpty()) {
+    $variables['field_uwm_columns_per_row'] = $grid_paragraph->get('field_uwm_columns_per_row')->first()->getValue()['value'];
+  }
+
   // If any of the child paragraphs are cards, style all as cards.
   $variables['style_as_cards'] = FALSE;
 
-  if (!empty($variables['content']['field_uwm_columns']) && !$grid_paragraph->get('field_uwm_columns')->isEmpty()) {
+  if (!empty($variables['content']['field_uwm_columns'][0]) && !empty($col_paragraphs)) {
 
     /** @var \Drupal\paragraphs\ParagraphInterface $col_paragraph */
-    foreach ($grid_paragraph->get('field_uwm_columns')->referencedEntities() as $col_paragraph) {
+    foreach ($col_paragraphs as $col_paragraph) {
 
       // Check for Card paragraph type.
       if ($col_paragraph->bundle() === 'uwm_card') {


### PR DESCRIPTION
Service & Specialty page finalization tweaks, round 2

* Cards in Grid - remove Bootstrap .card-deck wrapper, which set all cards in single row, regardless of total number; instead dynamically handle number of cards per row (including responsive) based on total number of cards. This applies generically to Grid/Cards components, not only to the intro cards on Service/Specialty pages.

* More spacing tweaks for grey-background section