### PR TITLE
hotfix/accordion-jump-link-38761146 > stage

### DIFF
--- a/docroot/themes/custom/uwmbase/components/accordion/accordion.twig
+++ b/docroot/themes/custom/uwmbase/components/accordion/accordion.twig
@@ -50,8 +50,15 @@ accordionSections = content.uwm_accordion_section #}
   <div class="card uwm-accordion__card border-0 mb-3">
     <div class="card-header uwm-accordion__card-header p-0 border-0" id="heading-{{ paragraph_id }}-{{ key + 1 }}">
       <h3>
+        {#
+          Include an 'id' on the button, to allow jump links to use the
+          animated scroll code that then triggers a click on the button and
+          opens this accordion section.
+          @see components/anchor-scroll/anchor-scroll.js
+        #}
         <button class="uwm-accordion__header-link btn {{ indicator_class }} {{ show_accordion_heading }}
             w-100"
+                id="button-{{ paragraph_id }}-{{ key + 1 }}"
                 data-toggle="collapse"
                 data-target="#collapse-{{ paragraph_id }}-{{ key + 1 }}"
                 aria-expanded="{{ aria }}"

--- a/docroot/themes/custom/uwmbase/components/anchor-scroll/anchor-scroll.js
+++ b/docroot/themes/custom/uwmbase/components/anchor-scroll/anchor-scroll.js
@@ -24,16 +24,6 @@
 
     attach(context, settings) {
 
-      // Add listener for anchor links clicked:
-      window.addEventListener('hashchange', () => {
-        init();
-      });
-
-      // Add listener for page load:
-      window.addEventListener("DOMContentLoaded", (event) => {
-        init();
-      });
-
       /**
        * Our main function to scroll to an anchor.
        */
@@ -100,6 +90,16 @@
         });
 
       };
+
+      // Run on initial page load by checking `context`:
+      if (context === document) {
+        init();
+      }
+
+      // Add listener for anchor links clicked:
+      window.addEventListener('hashchange', () => {
+        init();
+      });
 
     }
 

--- a/docroot/themes/custom/uwmbase/templates/paragraphs/paragraph--uwm-cta-link.html.twig
+++ b/docroot/themes/custom/uwmbase/templates/paragraphs/paragraph--uwm-cta-link.html.twig
@@ -25,11 +25,13 @@
 
   {#
     If this is a link to an ID/anchor elsewhere on the page, append the '---'
-    to trigger animated scroll handling. (Bypass the custom case that opens
-    a featured story modal.)
+    to trigger animated scroll handling, unless the user has included that
+    delimiter. (Also bypass the custom case that opens a featured story modal.)
     @see components/anchor-scroll/anchor-scroll.js
   #}
-  {% if (field_uwm_link__url starts with '#') and not (field_uwm_link__url starts with '#modal-') %}
+  {% if (field_uwm_link__url starts with '#')
+    and not ('---' in field_uwm_link__url)
+    and not (field_uwm_link__url starts with '#modal-') %}
     {% set field_uwm_link__url = field_uwm_link__url ~ '---' %}
   {% endif %}
 

--- a/docroot/themes/custom/uwmbase/templates/paragraphs/paragraph--uwm-cta-link.html.twig
+++ b/docroot/themes/custom/uwmbase/templates/paragraphs/paragraph--uwm-cta-link.html.twig
@@ -24,12 +24,14 @@
   %}
 
   {#
-    If this is a link to an ID/anchor elsewhere on the page, append the '---'
-    to trigger animated scroll handling, unless the user has included that
-    delimiter. (Also bypass the custom case that opens a featured story modal.)
+    If this is a link to an ID/anchor elsewhere on this page (URL starts with
+    '#') OR on a different page ('#' within URL), append the '---' to trigger
+    animated scroll handling (if the user did not enter the delimiter in the
+    field value).
+    Also bypass the custom case that opens a featured story modal.
     @see components/anchor-scroll/anchor-scroll.js
   #}
-  {% if (field_uwm_link__url starts with '#')
+  {% if ('#' in field_uwm_link__url)
     and not ('---' in field_uwm_link__url)
     and not (field_uwm_link__url starts with '#modal-') %}
     {% set field_uwm_link__url = field_uwm_link__url ~ '---' %}

--- a/docroot/themes/custom/uwmbase/uwmbase.info.yml
+++ b/docroot/themes/custom/uwmbase/uwmbase.info.yml
@@ -32,6 +32,13 @@ libraries-override:
 # The "libraries:" section will add a library to _all_ pages.
 libraries:
   - uwmbase/base
+  # Anchor scroll:
+  # There may be links on one page that desire to link to another page and
+  # scroll to an element on that page. But we cannot know in the code while
+  # loading that destination page that it needs to include this JS scroll
+  # functionality - the URL fragment is not sent to the server. Thus, include
+  # this globally to handle those cases when they arise.
+  - uwmbase/anchor-scroll
   # @TODO Remove these libraries and use attach_library() for all component styles.
   - uwmbase/box
   - uwmbase/comment


### PR DESCRIPTION
Extend jump link (UWM CTA paragraph) handling to scroll to and open an accordion section, and go to a different page and scroll to an element there.

This is used on a few service pages.

https://www.wrike.com/open.htm?id=387611464