### PR TITLE
hotfix/search-query-param-dupe-workaround > master

### DIFF
--- a/docroot/modules/custom/uwmed_uwmcms_search/uwmed_uwmcms_search.module
+++ b/docroot/modules/custom/uwmed_uwmcms_search/uwmed_uwmcms_search.module
@@ -607,6 +607,13 @@ function _uwmed_uwmcms_search_views_pre_render_set_results_title(ViewExecutable 
 
   if (!empty($specialty)) {
 
+    // TODO:
+    // Ensure unique specialty values. This is a workaround for the `expertise`
+    // query parameter being somehow programmatically duplicated when link field
+    // URLs are output.
+    // @see https://www.wrike.com/open.htm?id=401444121
+    $specialty = array_unique($specialty);
+
     // Combine multiple terms, if there are.
     $specialty = implode(", ", $specialty);
 


### PR DESCRIPTION
UWM-STEVIE: workaround for duplicated 'expertise' query parameter in 'See all Locations' button links to pre-filtered search