### PR TITLE
hotfix/config-provider-fields-view-modes-2019-10-22 > master

### DIFF
--- a/config/stevie/core.entity_view_display.node.res_provider.autocomplete.yml
+++ b/config/stevie/core.entity_view_display.node.res_provider.autocomplete.yml
@@ -4,25 +4,36 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.node.autocomplete
+    - field.field.node.res_provider.field_res_academic_title
     - field.field.node.res_provider.field_res_affiliates
     - field.field.node.res_provider.field_res_biography
     - field.field.node.res_provider.field_res_board_certifications
     - field.field.node.res_provider.field_res_clinics
+    - field.field.node.res_provider.field_res_conditions_symptoms
     - field.field.node.res_provider.field_res_degrees
+    - field.field.node.res_provider.field_res_department
     - field.field.node.res_provider.field_res_education_history
     - field.field.node.res_provider.field_res_expertises
     - field.field.node.res_provider.field_res_gender
     - field.field.node.res_provider.field_res_image
     - field.field.node.res_provider.field_res_internal_url
+    - field.field.node.res_provider.field_res_is_open_scheduling
     - field.field.node.res_provider.field_res_isacceptingnewpts
     - field.field.node.res_provider.field_res_languages
     - field.field.node.res_provider.field_res_medical_services
+    - field.field.node.res_provider.field_res_medical_title
     - field.field.node.res_provider.field_res_meta_tags
     - field.field.node.res_provider.field_res_name
+    - field.field.node.res_provider.field_res_node_videos
     - field.field.node.res_provider.field_res_npi
+    - field.field.node.res_provider.field_res_patients_treated
     - field.field.node.res_provider.field_res_personal_interests
+    - field.field.node.res_provider.field_res_procedures_treatments
+    - field.field.node.res_provider.field_res_provider_type
     - field.field.node.res_provider.field_res_pubmed_ids
     - field.field.node.res_provider.field_res_puma_id
+    - field.field.node.res_provider.field_res_ser_id
+    - field.field.node.res_provider.field_res_visit_type_id
     - field.field.node.res_provider.field_search_best_bets
     - field.field.node.res_provider.field_uwm_json_packet
     - field.field.node.res_provider.uwm_unique_id
@@ -71,11 +82,14 @@ content:
     third_party_settings: {  }
 hidden:
   field_node_videos: true
+  field_res_academic_title: true
   field_res_affiliates: true
   field_res_biography: true
   field_res_board_certifications: true
   field_res_clinics: true
+  field_res_conditions_symptoms: true
   field_res_degrees: true
+  field_res_department: true
   field_res_education_history: true
   field_res_expertises: true
   field_res_gender: true
@@ -85,13 +99,18 @@ hidden:
   field_res_isacceptingnewpts: true
   field_res_languages: true
   field_res_medical_services: true
+  field_res_medical_title: true
   field_res_meta_tags: true
   field_res_node_videos: true
   field_res_npi: true
+  field_res_patients_treated: true
   field_res_personal_interests: true
+  field_res_procedures_treatments: true
+  field_res_provider_type: true
   field_res_pubmed_ids: true
   field_res_puma_id: true
   field_res_ser_id: true
+  field_res_visit_type_id: true
   field_search_best_bets: true
   field_uwm_json_packet: true
   links: true

--- a/config/stevie/core.entity_view_display.node.res_provider.card.yml
+++ b/config/stevie/core.entity_view_display.node.res_provider.card.yml
@@ -4,11 +4,14 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.node.card
+    - field.field.node.res_provider.field_res_academic_title
     - field.field.node.res_provider.field_res_affiliates
     - field.field.node.res_provider.field_res_biography
     - field.field.node.res_provider.field_res_board_certifications
     - field.field.node.res_provider.field_res_clinics
+    - field.field.node.res_provider.field_res_conditions_symptoms
     - field.field.node.res_provider.field_res_degrees
+    - field.field.node.res_provider.field_res_department
     - field.field.node.res_provider.field_res_education_history
     - field.field.node.res_provider.field_res_expertises
     - field.field.node.res_provider.field_res_gender
@@ -18,14 +21,19 @@ dependencies:
     - field.field.node.res_provider.field_res_isacceptingnewpts
     - field.field.node.res_provider.field_res_languages
     - field.field.node.res_provider.field_res_medical_services
+    - field.field.node.res_provider.field_res_medical_title
     - field.field.node.res_provider.field_res_meta_tags
     - field.field.node.res_provider.field_res_name
     - field.field.node.res_provider.field_res_node_videos
     - field.field.node.res_provider.field_res_npi
+    - field.field.node.res_provider.field_res_patients_treated
     - field.field.node.res_provider.field_res_personal_interests
+    - field.field.node.res_provider.field_res_procedures_treatments
+    - field.field.node.res_provider.field_res_provider_type
     - field.field.node.res_provider.field_res_pubmed_ids
     - field.field.node.res_provider.field_res_puma_id
     - field.field.node.res_provider.field_res_ser_id
+    - field.field.node.res_provider.field_res_visit_type_id
     - field.field.node.res_provider.field_search_best_bets
     - field.field.node.res_provider.field_uwm_json_packet
     - field.field.node.res_provider.uwm_unique_id
@@ -108,23 +116,31 @@ content:
       multiple_el_al_first: '1'
     third_party_settings: {  }
 hidden:
+  field_res_academic_title: true
   field_res_affiliates: true
   field_res_biography: true
   field_res_board_certifications: true
   field_res_clinics: true
+  field_res_conditions_symptoms: true
   field_res_degrees: true
+  field_res_department: true
   field_res_education_history: true
   field_res_gender: true
   field_res_internal_url: true
   field_res_is_open_scheduling: true
   field_res_isacceptingnewpts: true
+  field_res_medical_title: true
   field_res_meta_tags: true
   field_res_node_videos: true
   field_res_npi: true
+  field_res_patients_treated: true
   field_res_personal_interests: true
+  field_res_procedures_treatments: true
+  field_res_provider_type: true
   field_res_pubmed_ids: true
   field_res_puma_id: true
   field_res_ser_id: true
+  field_res_visit_type_id: true
   field_search_best_bets: true
   field_uwm_json_packet: true
   links: true

--- a/config/stevie/core.entity_view_display.node.res_provider.provider_card.yml
+++ b/config/stevie/core.entity_view_display.node.res_provider.provider_card.yml
@@ -4,12 +4,14 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.node.provider_card
+    - field.field.node.res_provider.field_res_academic_title
     - field.field.node.res_provider.field_res_affiliates
     - field.field.node.res_provider.field_res_biography
     - field.field.node.res_provider.field_res_board_certifications
     - field.field.node.res_provider.field_res_clinics
     - field.field.node.res_provider.field_res_conditions_symptoms
     - field.field.node.res_provider.field_res_degrees
+    - field.field.node.res_provider.field_res_department
     - field.field.node.res_provider.field_res_education_history
     - field.field.node.res_provider.field_res_expertises
     - field.field.node.res_provider.field_res_gender
@@ -19,12 +21,15 @@ dependencies:
     - field.field.node.res_provider.field_res_isacceptingnewpts
     - field.field.node.res_provider.field_res_languages
     - field.field.node.res_provider.field_res_medical_services
+    - field.field.node.res_provider.field_res_medical_title
     - field.field.node.res_provider.field_res_meta_tags
     - field.field.node.res_provider.field_res_name
     - field.field.node.res_provider.field_res_node_videos
     - field.field.node.res_provider.field_res_npi
+    - field.field.node.res_provider.field_res_patients_treated
     - field.field.node.res_provider.field_res_personal_interests
     - field.field.node.res_provider.field_res_procedures_treatments
+    - field.field.node.res_provider.field_res_provider_type
     - field.field.node.res_provider.field_res_pubmed_ids
     - field.field.node.res_provider.field_res_puma_id
     - field.field.node.res_provider.field_res_ser_id

--- a/config/stevie/core.entity_view_display.node.res_provider.search_result.yml
+++ b/config/stevie/core.entity_view_display.node.res_provider.search_result.yml
@@ -4,25 +4,38 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.node.search_result
+    - field.field.node.res_provider.field_res_academic_title
     - field.field.node.res_provider.field_res_affiliates
     - field.field.node.res_provider.field_res_biography
     - field.field.node.res_provider.field_res_board_certifications
     - field.field.node.res_provider.field_res_clinics
+    - field.field.node.res_provider.field_res_conditions_symptoms
     - field.field.node.res_provider.field_res_degrees
+    - field.field.node.res_provider.field_res_department
     - field.field.node.res_provider.field_res_education_history
     - field.field.node.res_provider.field_res_expertises
     - field.field.node.res_provider.field_res_gender
     - field.field.node.res_provider.field_res_image
     - field.field.node.res_provider.field_res_internal_url
+    - field.field.node.res_provider.field_res_is_open_scheduling
     - field.field.node.res_provider.field_res_isacceptingnewpts
     - field.field.node.res_provider.field_res_languages
     - field.field.node.res_provider.field_res_medical_services
+    - field.field.node.res_provider.field_res_medical_title
     - field.field.node.res_provider.field_res_meta_tags
     - field.field.node.res_provider.field_res_name
+    - field.field.node.res_provider.field_res_node_videos
     - field.field.node.res_provider.field_res_npi
+    - field.field.node.res_provider.field_res_patients_treated
     - field.field.node.res_provider.field_res_personal_interests
+    - field.field.node.res_provider.field_res_procedures_treatments
+    - field.field.node.res_provider.field_res_provider_type
     - field.field.node.res_provider.field_res_pubmed_ids
     - field.field.node.res_provider.field_res_puma_id
+    - field.field.node.res_provider.field_res_ser_id
+    - field.field.node.res_provider.field_res_visit_type_id
+    - field.field.node.res_provider.field_search_best_bets
+    - field.field.node.res_provider.field_uwm_json_packet
     - field.field.node.res_provider.uwm_unique_id
     - node.type.res_provider
   module:
@@ -60,10 +73,13 @@ content:
     third_party_settings: {  }
 hidden:
   field_node_videos: true
+  field_res_academic_title: true
   field_res_affiliates: true
   field_res_board_certifications: true
   field_res_clinics: true
+  field_res_conditions_symptoms: true
   field_res_degrees: true
+  field_res_department: true
   field_res_education_history: true
   field_res_expertises: true
   field_res_gender: true
@@ -73,15 +89,21 @@ hidden:
   field_res_isacceptingnewpts: true
   field_res_languages: true
   field_res_medical_services: true
+  field_res_medical_title: true
   field_res_meta_tags: true
   field_res_name: true
   field_res_node_videos: true
   field_res_npi: true
+  field_res_patients_treated: true
   field_res_personal_interests: true
+  field_res_procedures_treatments: true
+  field_res_provider_type: true
   field_res_pubmed_ids: true
   field_res_puma_id: true
   field_res_ser_id: true
+  field_res_visit_type_id: true
   field_search_best_bets: true
   field_uwm_json_packet: true
   links: true
+  search_api_excerpt: true
   uwm_unique_id: true

--- a/config/stevie/core.entity_view_display.node.res_provider.teaser.yml
+++ b/config/stevie/core.entity_view_display.node.res_provider.teaser.yml
@@ -4,25 +4,38 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.node.teaser
+    - field.field.node.res_provider.field_res_academic_title
     - field.field.node.res_provider.field_res_affiliates
     - field.field.node.res_provider.field_res_biography
     - field.field.node.res_provider.field_res_board_certifications
     - field.field.node.res_provider.field_res_clinics
+    - field.field.node.res_provider.field_res_conditions_symptoms
     - field.field.node.res_provider.field_res_degrees
+    - field.field.node.res_provider.field_res_department
     - field.field.node.res_provider.field_res_education_history
     - field.field.node.res_provider.field_res_expertises
     - field.field.node.res_provider.field_res_gender
     - field.field.node.res_provider.field_res_image
     - field.field.node.res_provider.field_res_internal_url
+    - field.field.node.res_provider.field_res_is_open_scheduling
     - field.field.node.res_provider.field_res_isacceptingnewpts
     - field.field.node.res_provider.field_res_languages
     - field.field.node.res_provider.field_res_medical_services
+    - field.field.node.res_provider.field_res_medical_title
     - field.field.node.res_provider.field_res_meta_tags
     - field.field.node.res_provider.field_res_name
+    - field.field.node.res_provider.field_res_node_videos
     - field.field.node.res_provider.field_res_npi
+    - field.field.node.res_provider.field_res_patients_treated
     - field.field.node.res_provider.field_res_personal_interests
+    - field.field.node.res_provider.field_res_procedures_treatments
+    - field.field.node.res_provider.field_res_provider_type
     - field.field.node.res_provider.field_res_pubmed_ids
     - field.field.node.res_provider.field_res_puma_id
+    - field.field.node.res_provider.field_res_ser_id
+    - field.field.node.res_provider.field_res_visit_type_id
+    - field.field.node.res_provider.field_search_best_bets
+    - field.field.node.res_provider.field_uwm_json_packet
     - field.field.node.res_provider.uwm_unique_id
     - node.type.res_provider
   module:
@@ -85,24 +98,32 @@ content:
 hidden:
   field_name: true
   field_node_videos: true
+  field_res_academic_title: true
   field_res_affiliates: true
   field_res_biography: true
   field_res_board_certifications: true
   field_res_clinics: true
+  field_res_conditions_symptoms: true
   field_res_degrees: true
+  field_res_department: true
   field_res_education_history: true
   field_res_expertises: true
   field_res_gender: true
   field_res_image: true
   field_res_internal_url: true
   field_res_is_open_scheduling: true
+  field_res_medical_title: true
   field_res_meta_tags: true
   field_res_node_videos: true
   field_res_npi: true
+  field_res_patients_treated: true
   field_res_personal_interests: true
+  field_res_procedures_treatments: true
+  field_res_provider_type: true
   field_res_pubmed_ids: true
   field_res_puma_id: true
   field_res_ser_id: true
+  field_res_visit_type_id: true
   field_search_best_bets: true
   field_uwm_json_packet: true
   search_api_excerpt: true


### PR DESCRIPTION
Update provider view mode display configs with missing fields. (Not sure why this didn't come up in previous local diffs...)