### PR TITLE
UWM-STEVIE: hotfix restore config_ignore settings with numeric index format

### DIFF
--- a/config/stevie/config_ignore.settings.yml
+++ b/config/stevie/config_ignore.settings.yml
@@ -1,7 +1,7 @@
 ignored_config_entities:
-  - acquia_connector.settings
-  - media_acquiadam.settings
-  - d8_google_optimize_hide_page.settings
-  - 'webform.webform.*'
+  0: acquia_connector.settings
+  1: media_acquiadam.settings
+  2: d8_google_optimize_hide_page.settings
+  3: 'webform.webform.*'
 _core:
   default_config_hash: UVH1aJ4b44UM-VdPVN7hNNuuVqfReJxwfVeDQH1Hvsk


### PR DESCRIPTION
This reverts the change to the dashed list format merged to master here:
https://github.com/uwmweb/uwmcms/pull/1270/files#diff-b74391091b7a121de029087090c2045e