### PR TITLE
hotfix/videos-disable-autoplay > master

### DIFF
--- a/config/stevie/core.entity_view_display.media.video.default.yml
+++ b/config/stevie/core.entity_view_display.media.video.default.yml
@@ -23,12 +23,13 @@ content:
       responsive: true
       width: 854
       height: 480
-      autoplay: true
+      autoplay: false
     third_party_settings: {  }
     region: content
 hidden:
   created: true
   field_media_in_library: true
   name: true
+  search_api_excerpt: true
   thumbnail: true
   uid: true

--- a/config/stevie/core.entity_view_display.media.video_embed.default.yml
+++ b/config/stevie/core.entity_view_display.media.video_embed.default.yml
@@ -17,10 +17,10 @@ content:
     weight: 0
     label: hidden
     settings:
-      autoplay: true
       responsive: true
       width: 854
       height: 480
+      autoplay: false
     third_party_settings: {  }
     type: video_embed_field_video
     region: content
@@ -28,5 +28,6 @@ hidden:
   created: true
   field_media_in_library: true
   name: true
+  search_api_excerpt: true
   thumbnail: true
   uid: true


### PR DESCRIPTION
Set Video Embed and Remote Video media entities to NOT autoplay in Default view mode
(Applies globally to the site, per Daniel request)

Example: https://www.uwmedicine.org/airliftnw/protocols-training