### PR TITLE
hotfix/videos-disable-autoplay > stage

### DIFF
--- a/config/stevie/core.entity_form_display.node.res_clinic.default.yml
+++ b/config/stevie/core.entity_form_display.node.res_clinic.default.yml
@@ -30,6 +30,7 @@ dependencies:
     - field.field.node.res_clinic.field_res_is_building
     - field.field.node.res_clinic.field_res_is_hospital
     - field.field.node.res_clinic.field_res_iscallcenterserviced
+    - field.field.node.res_clinic.field_res_location_note
     - field.field.node.res_clinic.field_res_medical_services
     - field.field.node.res_clinic.field_res_meta_tags
     - field.field.node.res_clinic.field_res_patients_treated
@@ -118,6 +119,7 @@ third_party_settings:
         - field_res_expertises
         - field_uwm_sections
         - body
+        - field_res_location_note
       parent_name: ''
       weight: 3
       format_type: fieldset
@@ -367,6 +369,14 @@ content:
       display_label: true
     third_party_settings: {  }
     type: boolean_checkbox
+    region: content
+  field_res_location_note:
+    weight: 16
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+    type: text_textarea
     region: content
   field_res_medical_services:
     weight: 6

--- a/config/stevie/core.entity_view_display.media.video.default.yml
+++ b/config/stevie/core.entity_view_display.media.video.default.yml
@@ -23,12 +23,13 @@ content:
       responsive: true
       width: 854
       height: 480
-      autoplay: true
+      autoplay: false
     third_party_settings: {  }
     region: content
 hidden:
   created: true
   field_media_in_library: true
   name: true
+  search_api_excerpt: true
   thumbnail: true
   uid: true

--- a/config/stevie/core.entity_view_display.media.video_embed.default.yml
+++ b/config/stevie/core.entity_view_display.media.video_embed.default.yml
@@ -17,10 +17,10 @@ content:
     weight: 0
     label: hidden
     settings:
-      autoplay: true
       responsive: true
       width: 854
       height: 480
+      autoplay: false
     third_party_settings: {  }
     type: video_embed_field_video
     region: content
@@ -28,5 +28,6 @@ hidden:
   created: true
   field_media_in_library: true
   name: true
+  search_api_excerpt: true
   thumbnail: true
   uid: true

--- a/config/stevie/core.entity_view_display.node.res_clinic.card.yml
+++ b/config/stevie/core.entity_view_display.node.res_clinic.card.yml
@@ -31,6 +31,7 @@ dependencies:
     - field.field.node.res_clinic.field_res_is_building
     - field.field.node.res_clinic.field_res_is_hospital
     - field.field.node.res_clinic.field_res_iscallcenterserviced
+    - field.field.node.res_clinic.field_res_location_note
     - field.field.node.res_clinic.field_res_medical_services
     - field.field.node.res_clinic.field_res_meta_tags
     - field.field.node.res_clinic.field_res_patients_treated
@@ -144,6 +145,7 @@ hidden:
   field_res_is_building: true
   field_res_is_hospital: true
   field_res_iscallcenterserviced: true
+  field_res_location_note: true
   field_res_meta_tags: true
   field_res_patients_treated: true
   field_res_procedures_treatments: true

--- a/config/stevie/core.entity_view_display.node.res_clinic.card.yml
+++ b/config/stevie/core.entity_view_display.node.res_clinic.card.yml
@@ -6,16 +6,21 @@ dependencies:
     - core.entity_view_mode.node.card
     - field.field.node.res_clinic.body
     - field.field.node.res_clinic.field_featured
+    - field.field.node.res_clinic.field_hide_see_clinics_cta
     - field.field.node.res_clinic.field_res_affiliates
     - field.field.node.res_clinic.field_res_box_number
     - field.field.node.res_clinic.field_res_building
     - field.field.node.res_clinic.field_res_clockwise_id
+    - field.field.node.res_clinic.field_res_conditions_symptoms
+    - field.field.node.res_clinic.field_res_department
     - field.field.node.res_clinic.field_res_epic_department_ids
     - field.field.node.res_clinic.field_res_expertises
     - field.field.node.res_clinic.field_res_external_url
     - field.field.node.res_clinic.field_res_fax_number
     - field.field.node.res_clinic.field_res_feat_clinics_header
+    - field.field.node.res_clinic.field_res_feat_clinics_view_all
     - field.field.node.res_clinic.field_res_featured_clinics
+    - field.field.node.res_clinic.field_res_features_amenities
     - field.field.node.res_clinic.field_res_floor
     - field.field.node.res_clinic.field_res_hide_appt_ctas
     - field.field.node.res_clinic.field_res_hide_open_scheduling
@@ -23,11 +28,14 @@ dependencies:
     - field.field.node.res_clinic.field_res_hours_of_operation
     - field.field.node.res_clinic.field_res_image
     - field.field.node.res_clinic.field_res_internal_url
+    - field.field.node.res_clinic.field_res_is_building
     - field.field.node.res_clinic.field_res_is_hospital
     - field.field.node.res_clinic.field_res_iscallcenterserviced
     - field.field.node.res_clinic.field_res_medical_services
     - field.field.node.res_clinic.field_res_meta_tags
+    - field.field.node.res_clinic.field_res_patients_treated
     - field.field.node.res_clinic.field_res_phone_number
+    - field.field.node.res_clinic.field_res_procedures_treatments
     - field.field.node.res_clinic.field_res_providers
     - field.field.node.res_clinic.field_res_room_number
     - field.field.node.res_clinic.field_search_best_bets

--- a/config/stevie/core.entity_view_display.node.res_clinic.default.yml
+++ b/config/stevie/core.entity_view_display.node.res_clinic.default.yml
@@ -30,6 +30,7 @@ dependencies:
     - field.field.node.res_clinic.field_res_is_building
     - field.field.node.res_clinic.field_res_is_hospital
     - field.field.node.res_clinic.field_res_iscallcenterserviced
+    - field.field.node.res_clinic.field_res_location_note
     - field.field.node.res_clinic.field_res_medical_services
     - field.field.node.res_clinic.field_res_meta_tags
     - field.field.node.res_clinic.field_res_patients_treated
@@ -219,6 +220,13 @@ content:
       format_custom_true: ''
     third_party_settings: {  }
     type: boolean
+    region: content
+  field_res_location_note:
+    weight: 28
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    type: text_default
     region: content
   field_res_patients_treated:
     weight: 25

--- a/config/stevie/core.entity_view_display.node.res_clinic.full.yml
+++ b/config/stevie/core.entity_view_display.node.res_clinic.full.yml
@@ -6,10 +6,13 @@ dependencies:
     - core.entity_view_mode.node.full
     - field.field.node.res_clinic.body
     - field.field.node.res_clinic.field_featured
+    - field.field.node.res_clinic.field_hide_see_clinics_cta
     - field.field.node.res_clinic.field_res_affiliates
     - field.field.node.res_clinic.field_res_box_number
     - field.field.node.res_clinic.field_res_building
     - field.field.node.res_clinic.field_res_clockwise_id
+    - field.field.node.res_clinic.field_res_conditions_symptoms
+    - field.field.node.res_clinic.field_res_department
     - field.field.node.res_clinic.field_res_epic_department_ids
     - field.field.node.res_clinic.field_res_expertises
     - field.field.node.res_clinic.field_res_external_url
@@ -17,6 +20,7 @@ dependencies:
     - field.field.node.res_clinic.field_res_feat_clinics_header
     - field.field.node.res_clinic.field_res_feat_clinics_view_all
     - field.field.node.res_clinic.field_res_featured_clinics
+    - field.field.node.res_clinic.field_res_features_amenities
     - field.field.node.res_clinic.field_res_floor
     - field.field.node.res_clinic.field_res_hide_appt_ctas
     - field.field.node.res_clinic.field_res_hide_open_scheduling
@@ -24,11 +28,15 @@ dependencies:
     - field.field.node.res_clinic.field_res_hours_of_operation
     - field.field.node.res_clinic.field_res_image
     - field.field.node.res_clinic.field_res_internal_url
+    - field.field.node.res_clinic.field_res_is_building
     - field.field.node.res_clinic.field_res_is_hospital
     - field.field.node.res_clinic.field_res_iscallcenterserviced
+    - field.field.node.res_clinic.field_res_location_note
     - field.field.node.res_clinic.field_res_medical_services
     - field.field.node.res_clinic.field_res_meta_tags
+    - field.field.node.res_clinic.field_res_patients_treated
     - field.field.node.res_clinic.field_res_phone_number
+    - field.field.node.res_clinic.field_res_procedures_treatments
     - field.field.node.res_clinic.field_res_providers
     - field.field.node.res_clinic.field_res_room_number
     - field.field.node.res_clinic.field_search_best_bets
@@ -170,6 +178,13 @@ content:
     third_party_settings: {  }
     type: responsive_image
     region: content
+  field_res_location_note:
+    type: text_default
+    weight: 19
+    region: content
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
   field_res_phone_number:
     weight: 4
     label: hidden

--- a/config/stevie/core.entity_view_display.node.res_clinic.teaser.yml
+++ b/config/stevie/core.entity_view_display.node.res_clinic.teaser.yml
@@ -6,24 +6,37 @@ dependencies:
     - core.entity_view_mode.node.teaser
     - field.field.node.res_clinic.body
     - field.field.node.res_clinic.field_featured
+    - field.field.node.res_clinic.field_hide_see_clinics_cta
     - field.field.node.res_clinic.field_res_affiliates
     - field.field.node.res_clinic.field_res_box_number
     - field.field.node.res_clinic.field_res_building
     - field.field.node.res_clinic.field_res_clockwise_id
+    - field.field.node.res_clinic.field_res_conditions_symptoms
+    - field.field.node.res_clinic.field_res_department
+    - field.field.node.res_clinic.field_res_epic_department_ids
     - field.field.node.res_clinic.field_res_expertises
     - field.field.node.res_clinic.field_res_external_url
     - field.field.node.res_clinic.field_res_fax_number
     - field.field.node.res_clinic.field_res_feat_clinics_header
+    - field.field.node.res_clinic.field_res_feat_clinics_view_all
     - field.field.node.res_clinic.field_res_featured_clinics
+    - field.field.node.res_clinic.field_res_features_amenities
     - field.field.node.res_clinic.field_res_floor
+    - field.field.node.res_clinic.field_res_hide_appt_ctas
+    - field.field.node.res_clinic.field_res_hide_open_scheduling
+    - field.field.node.res_clinic.field_res_hide_returning_cta
     - field.field.node.res_clinic.field_res_hours_of_operation
     - field.field.node.res_clinic.field_res_image
     - field.field.node.res_clinic.field_res_internal_url
+    - field.field.node.res_clinic.field_res_is_building
     - field.field.node.res_clinic.field_res_is_hospital
     - field.field.node.res_clinic.field_res_iscallcenterserviced
+    - field.field.node.res_clinic.field_res_location_note
     - field.field.node.res_clinic.field_res_medical_services
     - field.field.node.res_clinic.field_res_meta_tags
+    - field.field.node.res_clinic.field_res_patients_treated
     - field.field.node.res_clinic.field_res_phone_number
+    - field.field.node.res_clinic.field_res_procedures_treatments
     - field.field.node.res_clinic.field_res_providers
     - field.field.node.res_clinic.field_res_room_number
     - field.field.node.res_clinic.field_search_best_bets
@@ -76,6 +89,7 @@ hidden:
   field_res_is_building: true
   field_res_is_hospital: true
   field_res_iscallcenterserviced: true
+  field_res_location_note: true
   field_res_medical_services: true
   field_res_meta_tags: true
   field_res_patients_treated: true

--- a/config/stevie/field.field.node.res_clinic.field_res_location_note.yml
+++ b/config/stevie/field.field.node.res_clinic.field_res_location_note.yml
@@ -1,0 +1,29 @@
+uuid: 1efdf5ae-3acc-414f-b6bc-35ae09d9818a
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_res_location_note
+    - node.type.res_clinic
+  module:
+    - allowed_formats
+    - text
+third_party_settings:
+  allowed_formats:
+    rich_text: rich_text
+    basic_html: '0'
+    unrestricted: '0'
+    unrestricted_no_wysiwyg: '0'
+    plain_text: '0'
+id: node.res_clinic.field_res_location_note
+field_name: field_res_location_note
+entity_type: node
+bundle: res_clinic
+label: 'Location Note'
+description: 'Custom note to provide additional information about a clinic as needed'
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: text_long

--- a/config/stevie/field.field.node.res_provider.field_res_image.yml
+++ b/config/stevie/field.field.node.res_provider.field_res_image.yml
@@ -25,7 +25,7 @@ settings:
   max_filesize: ''
   max_resolution: ''
   min_resolution: ''
-  alt_field: true
+  alt_field: false
   alt_field_required: false
   title_field: false
   title_field_required: false

--- a/config/stevie/field.storage.node.field_res_location_note.yml
+++ b/config/stevie/field.storage.node.field_res_location_note.yml
@@ -1,0 +1,19 @@
+uuid: 3b99afe7-6f26-40ce-ae4b-21af87bfaab0
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - text
+id: node.field_res_location_note
+field_name: field_res_location_note
+entity_type: node
+type: text_long
+settings: {  }
+module: text
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/docroot/themes/custom/uwmbase/components/clinic-page/node--res-clinic--full.html.twig
+++ b/docroot/themes/custom/uwmbase/components/clinic-page/node--res-clinic--full.html.twig
@@ -287,6 +287,7 @@
                 </div>
               {% endif %}
             {% endif %}
+
           </div>
         </div>
 
@@ -335,6 +336,14 @@
         </div>
         {# Adding a second row of columns to accomodate 911 text at the very bottom in mobile and tablet #}
         <div class="clinic-page__right-two">
+          {#
+            This is a spot to add custom notes about a location
+          #}
+          {% if content.field_res_location_note.0 is not empty %}
+            <div class="clinic-page__note clinic-page__note-emergency">
+              {{ content.field_res_location_note }}
+            </div>
+          {% endif %}
           {#
              This text is stored in a custom content block so it's manageable
              in the admin UI.

--- a/docroot/themes/custom/uwmbase/uwmbase.theme
+++ b/docroot/themes/custom/uwmbase/uwmbase.theme
@@ -864,6 +864,60 @@ function uwmbase_preprocess_container(&$variables) {
 }
 
 /**
+ * Implements template_preprocess_responsive_image_formatter().
+ */
+function uwmbase_preprocess_responsive_image_formatter(array &$variables) {
+
+  // Set up res provider to use parent node's title as an
+  // alt tag for the res provider image.
+  $node = $variables['item']->getEntity();
+
+  if ($node->bundle() == 'res_provider') {
+    $variables['responsive_image']['#attributes']['data-provider_label'] = $node->get('title')->getString();
+  }
+
+}
+
+/**
+ * Implements template_preprocess_image_formatter().
+ */
+function uwmbase_preprocess_image_formatter(array &$variables) {
+
+  // Set up res provider to use parent node's title as an
+  // alt tag for the res provider image.
+  $node = $variables['item']->getEntity();
+
+  if ($node->bundle() == 'res_provider') {
+    $variables['image']['#attributes']['data-provider_label'] = $node->get('title')->getString();
+  }
+
+}
+
+/**
+ * Implements template_preprocess_responsive_image().
+ */
+function uwmbase_preprocess_responsive_image(&$variables) {
+
+  // Use the preprocessed template_preprocess_responsive_image_formatter()
+  // to set alt tag to parent node title.
+  if (isset($variables['img_element']['#attributes']['data-provider_label'])) {
+    $variables['img_element']['#attributes']['alt'] = 'Provider headshot of' . $variables['img_element']['#attributes']['data-provider_label'];
+  }
+}
+
+/**
+ * Implements template_preprocess_image().
+ */
+function uwmbase_preprocess_image(&$variables) {
+
+  // Use the preprocessed template_responsive_image_formatter()
+  // to set alt tag to parent node title.
+  if (isset($variables['attributes']['data-provider_label'])) {
+    $variables['attributes']['alt'] = 'Provider headshot of' . $variables['attributes']['data-provider_label'];
+  }
+}
+
+/**
  * Implements template_preprocess_field().
  */
 function uwmbase_preprocess_field(&$variables, $hook) {


### PR DESCRIPTION
Set Video Embed and Remote Video media entities to NOT autoplay in Default view mode
(Applies globally to the site, per Daniel request)

Example: https://www.uwmedicine.org/airliftnw/protocols-training