### PR TITLE
maintenance/config-ignore-2.2-settings-format > stage

### DIFF
--- a/.composer_show.out
+++ b/.composer_show.out
@@ -85,7 +85,7 @@ drupal/cog                                     1.13.0
 drupal/components                              1.0.0                  
 drupal/conditional_fields                      1.0.0-alpha4           
 drupal/config_filter                           1.4.0                  
-drupal/config_ignore                           2.1.0                  
+drupal/config_ignore                           2.2.0                  
 drupal/config_installer                        1.8.0                  
 drupal/config_split                            1.4.0                  
 drupal/config_update                           1.6.0                  

--- a/composer.lock
+++ b/composer.lock
@@ -4936,17 +4936,17 @@
         },
         {
             "name": "drupal/config_ignore",
-            "version": "2.1.0",
+            "version": "2.2.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/config_ignore.git",
-                "reference": "8.x-2.1"
+                "reference": "8.x-2.2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/config_ignore-8.x-2.1.zip",
-                "reference": "8.x-2.1",
-                "shasum": "07e00684930706632b3f2fc2a7433ffdae57cde7"
+                "url": "https://ftp.drupal.org/files/projects/config_ignore-8.x-2.2.zip",
+                "reference": "8.x-2.2",
+                "shasum": "18af5772087b90dd4b83c2c6e292d8ea2f8834e0"
             },
             "require": {
                 "drupal/config_filter": "1.*",
@@ -4958,8 +4958,8 @@
                     "dev-2.x": "2.x-dev"
                 },
                 "drupal": {
-                    "version": "8.x-2.1",
-                    "datestamp": "1507706044",
+                    "version": "8.x-2.2",
+                    "datestamp": "1576528386",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -4981,6 +4981,10 @@
                     "name": "Fabian Bircher",
                     "homepage": "https://www.drupal.org/u/bircher",
                     "role": "Maintainer"
+                },
+                {
+                    "name": "tlyngej",
+                    "homepage": "https://www.drupal.org/user/413139"
                 }
             ],
             "description": "Ignore certain configuration during import.",

--- a/config/calendar/config_ignore.settings.yml
+++ b/config/calendar/config_ignore.settings.yml
@@ -1,5 +1,5 @@
 ignored_config_entities:
-  0: acquia_lift.settings
-  2: acquia_contenthub.admin_settings
+  - acquia_lift.settings
+  - acquia_contenthub.admin_settings
 _core:
   default_config_hash: UVH1aJ4b44UM-VdPVN7hNNuuVqfReJxwfVeDQH1Hvsk

--- a/config/chew/config_ignore.settings.yml
+++ b/config/chew/config_ignore.settings.yml
@@ -1,5 +1,5 @@
 ignored_config_entities:
-  0: fb_instant_articles.settings
-  2: 'webform.webform.*'
+  - fb_instant_articles.settings
+  - 'webform.webform.*'
 _core:
   default_config_hash: UVH1aJ4b44UM-VdPVN7hNNuuVqfReJxwfVeDQH1Hvsk

--- a/config/contentrepo/config_ignore.settings.yml
+++ b/config/contentrepo/config_ignore.settings.yml
@@ -1,5 +1,5 @@
 ignored_config_entities:
-  0: acquia_connector.settings
-  2: media_acquiadam.settings
+  - acquia_connector.settings
+  - media_acquiadam.settings
 _core:
   default_config_hash: UVH1aJ4b44UM-VdPVN7hNNuuVqfReJxwfVeDQH1Hvsk

--- a/config/default/config_ignore.settings.yml
+++ b/config/default/config_ignore.settings.yml
@@ -4,5 +4,6 @@ ignored_config_entities:
   - devel.toolbar.settings
   - system.menu.devel
   - d8_google_optimize_hide_page.settings
+  - 'webform.webform.*'
 _core:
   default_config_hash: UVH1aJ4b44UM-VdPVN7hNNuuVqfReJxwfVeDQH1Hvsk

--- a/config/default/config_ignore.settings.yml
+++ b/config/default/config_ignore.settings.yml
@@ -1,9 +1,8 @@
 ignored_config_entities:
-  0: acquia_connector.settings
-  2: devel.settings
-  4: devel.toolbar.settings
-  6: system.menu.devel
-  8: d8_google_optimize_hide_page.settings
-  10: 'webform.webform.*'
+  - acquia_connector.settings
+  - devel.settings
+  - devel.toolbar.settings
+  - system.menu.devel
+  - d8_google_optimize_hide_page.settings
 _core:
   default_config_hash: UVH1aJ4b44UM-VdPVN7hNNuuVqfReJxwfVeDQH1Hvsk

--- a/config/default/config_split.config_split.prod.yml
+++ b/config/default/config_split.config_split.prod.yml
@@ -10,7 +10,6 @@ module: {  }
 theme: {  }
 blacklist: {  }
 graylist:
-  - config_ignore.settings
   - d8_google_optimize_hide_page.settings
 graylist_dependents: false
 graylist_skip_equal: true

--- a/config/envs/prod/default/config_ignore.settings.yml
+++ b/config/envs/prod/default/config_ignore.settings.yml
@@ -1,8 +1,0 @@
-ignored_config_entities:
-  0: acquia_connector.settings
-  2: devel.settings
-  4: devel.toolbar.settings
-  6: system.menu.devel
-  7: d8_google_optimize_hide_page.settings
-_core:
-  default_config_hash: UVH1aJ4b44UM-VdPVN7hNNuuVqfReJxwfVeDQH1Hvsk

--- a/config/envs/prod/stevie/config_ignore.settings.yml
+++ b/config/envs/prod/stevie/config_ignore.settings.yml
@@ -1,7 +1,0 @@
-ignored_config_entities:
-  0: acquia_connector.settings
-  1: media_acquiadam.settings
-  2: d8_google_optimize_hide_page.settings
-  3: 'webform.webform.*'
-_core:
-  default_config_hash: UVH1aJ4b44UM-VdPVN7hNNuuVqfReJxwfVeDQH1Hvsk

--- a/config/envs/stage/default/config_ignore.settings.yml
+++ b/config/envs/stage/default/config_ignore.settings.yml
@@ -1,8 +1,0 @@
-ignored_config_entities:
-  0: acquia_connector.settings
-  2: devel.settings
-  4: devel.toolbar.settings
-  6: system.menu.devel
-  7: d8_google_optimize_hide_page.settings
-_core:
-  default_config_hash: UVH1aJ4b44UM-VdPVN7hNNuuVqfReJxwfVeDQH1Hvsk

--- a/config/huddle/config_ignore.settings.yml
+++ b/config/huddle/config_ignore.settings.yml
@@ -1,6 +1,6 @@
 ignored_config_entities:
-  0: acquia_lift.settings
-  2: acquia_contenthub.admin_settings
-  4: 'webform.webform.*'
+  - acquia_lift.settings
+  - acquia_contenthub.admin_settings
+  - 'webform.webform.*'
 _core:
   default_config_hash: UVH1aJ4b44UM-VdPVN7hNNuuVqfReJxwfVeDQH1Hvsk

--- a/config/stevie/config_ignore.settings.yml
+++ b/config/stevie/config_ignore.settings.yml
@@ -1,7 +1,7 @@
 ignored_config_entities:
-  0: acquia_connector.settings
-  1: media_acquiadam.settings
-  2: d8_google_optimize_hide_page.settings
-  3: 'webform.webform.*'
+  - acquia_connector.settings
+  - media_acquiadam.settings
+  - d8_google_optimize_hide_page.settings
+  - 'webform.webform.*'
 _core:
   default_config_hash: UVH1aJ4b44UM-VdPVN7hNNuuVqfReJxwfVeDQH1Hvsk

--- a/config/stevie/config_split.config_split.prod.yml
+++ b/config/stevie/config_split.config_split.prod.yml
@@ -10,7 +10,6 @@ module: {  }
 theme: {  }
 blacklist: {  }
 graylist:
-  - config_ignore.settings
   - d8_google_optimize_hide_page.settings
   - search_api.server.acquia_search_server
 graylist_dependents: false

--- a/config/stevie/core.entity_form_display.node.res_clinic.default.yml
+++ b/config/stevie/core.entity_form_display.node.res_clinic.default.yml
@@ -67,7 +67,7 @@ third_party_settings:
         - field_res_box_number
         - field_res_image
       parent_name: ''
-      weight: 2
+      weight: 3
       format_type: fieldset
       format_settings:
         id: ''
@@ -80,7 +80,7 @@ third_party_settings:
       children:
         - field_uwm_sections_2
       parent_name: ''
-      weight: 6
+      weight: 7
       format_type: fieldset
       format_settings:
         id: ''
@@ -125,7 +125,7 @@ third_party_settings:
         - body
         - field_res_location_note
       parent_name: ''
-      weight: 4
+      weight: 5
       format_type: fieldset
       format_settings:
         label: 'Overview/Resources tab'
@@ -139,7 +139,7 @@ third_party_settings:
       children:
         - field_res_providers
       parent_name: ''
-      weight: 5
+      weight: 6
       format_type: fieldset
       format_settings:
         id: ''
@@ -153,7 +153,7 @@ third_party_settings:
         - field_uwm_content_owner
         - field_uwm_subject_matter_experts
       parent_name: ''
-      weight: 21
+      weight: 22
       format_type: details
       format_settings:
         id: ''
@@ -161,6 +161,19 @@ third_party_settings:
         open: false
         required_fields: true
       label: 'Content Contacts'
+    group_hours:
+      children:
+        - field_res_hours_of_operation
+      parent_name: ''
+      weight: 2
+      format_type: tab
+      format_settings:
+        id: ''
+        classes: ''
+        formatter: closed
+        description: ''
+        required_fields: true
+      label: Hours
       region: content
 _core:
   default_config_hash: 2kAi-wYe7ZuIze154ZwVwwhYSRqonPwtA675m4-PbdU
@@ -170,7 +183,7 @@ bundle: res_clinic
 mode: default
 content:
   body:
-    weight: 15
+    weight: 16
     settings:
       rows: 9
       summary_rows: 3
@@ -180,7 +193,7 @@ content:
     region: content
   created:
     type: datetime_timestamp
-    weight: 14
+    weight: 15
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -199,7 +212,7 @@ content:
     type: boolean_checkbox
     region: content
   field_res_affiliates:
-    weight: 12
+    weight: 13
     settings:
       match_operator: CONTAINS
       size: 60
@@ -234,7 +247,7 @@ content:
     region: content
   field_res_conditions_symptoms:
     type: entity_reference_autocomplete
-    weight: 8
+    weight: 9
     region: content
     settings:
       match_operator: CONTAINS
@@ -242,7 +255,7 @@ content:
       placeholder: ''
     third_party_settings: {  }
   field_res_department:
-    weight: 22
+    weight: 23
     settings:
       match_operator: CONTAINS
       size: 60
@@ -260,7 +273,7 @@ content:
     region: content
   field_res_expertises:
     type: entity_reference_autocomplete
-    weight: 13
+    weight: 14
     region: content
     settings:
       match_operator: CONTAINS
@@ -309,7 +322,7 @@ content:
     region: content
   field_res_features_amenities:
     type: entity_reference_autocomplete
-    weight: 11
+    weight: 12
     region: content
     settings:
       match_operator: CONTAINS
@@ -346,6 +359,24 @@ content:
     third_party_settings: {  }
     type: boolean_checkbox
     region: content
+  field_res_hours_of_operation:
+    type: paragraphs
+    weight: 34
+    region: content
+    settings:
+      title: Paragraph
+      title_plural: Paragraphs
+      edit_mode: open
+      closed_mode: summary
+      autocollapse: none
+      closed_mode_threshold: 0
+      add_mode: dropdown
+      form_display_mode: default
+      default_paragraph_type: ''
+      features:
+        duplicate: duplicate
+        collapse_edit_all: collapse_edit_all
+    third_party_settings: {  }
   field_res_image:
     weight: 35
     settings:
@@ -392,7 +423,7 @@ content:
     type: text_textarea
     region: content
   field_res_medical_services:
-    weight: 7
+    weight: 8
     settings:
       match_operator: CONTAINS
       size: 60
@@ -401,13 +432,13 @@ content:
     type: entity_reference_autocomplete
     region: content
   field_res_meta_tags:
-    weight: 18
+    weight: 19
     settings: {  }
     third_party_settings: {  }
     type: metatag_firehose
     region: content
   field_res_patients_treated:
-    weight: 10
+    weight: 11
     settings:
       match_operator: CONTAINS
       size: 60
@@ -424,7 +455,7 @@ content:
     region: content
   field_res_procedures_treatments:
     type: entity_reference_autocomplete
-    weight: 9
+    weight: 10
     region: content
     settings:
       match_operator: CONTAINS
@@ -468,7 +499,7 @@ content:
     region: content
   field_uwm_banner_content:
     type: paragraphs
-    weight: 3
+    weight: 4
     settings:
       title: 'Banner Content'
       title_plural: 'Banner Content'
@@ -495,7 +526,7 @@ content:
     type: entity_reference_autocomplete
     region: content
   field_uwm_sections:
-    weight: 14
+    weight: 15
     settings:
       title: section
       title_plural: sections
@@ -542,7 +573,7 @@ content:
     type: entity_reference_autocomplete
     region: content
   moderation_state:
-    weight: 19
+    weight: 20
     settings:
       size: 60
       placeholder: ''
@@ -553,21 +584,21 @@ content:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 16
+    weight: 17
     region: content
     third_party_settings: {  }
   status:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 13
+    weight: 14
     third_party_settings: {  }
     region: content
   sticky:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 17
+    weight: 18
     region: content
     third_party_settings: {  }
   title:
@@ -580,7 +611,7 @@ content:
     third_party_settings: {  }
   uid:
     type: entity_reference_autocomplete
-    weight: 15
+    weight: 16
     settings:
       match_operator: CONTAINS
       size: 60
@@ -588,7 +619,7 @@ content:
     region: content
     third_party_settings: {  }
   url_redirects:
-    weight: 20
+    weight: 21
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -601,7 +632,6 @@ content:
     type: string_textfield
     region: content
 hidden:
-  field_res_hours_of_operation: true
   field_test_m_services2: true
   field_uwm_json_packet: true
   path: true

--- a/config/stevie/core.entity_form_display.paragraph.hours_for_day.default.yml
+++ b/config/stevie/core.entity_form_display.paragraph.hours_for_day.default.yml
@@ -1,0 +1,36 @@
+uuid: 14658b71-f240-409c-9e5b-9482b3cd974b
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.hours_for_day.field_res_day
+    - field.field.paragraph.hours_for_day.field_res_end_time
+    - field.field.paragraph.hours_for_day.field_res_start_time
+    - paragraphs.paragraphs_type.hours_for_day
+id: paragraph.hours_for_day.default
+targetEntityType: paragraph
+bundle: hours_for_day
+mode: default
+content:
+  field_res_day:
+    type: options_select
+    weight: 0
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_res_end_time:
+    type: options_select
+    weight: 2
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_res_start_time:
+    type: options_select
+    weight: 1
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+hidden:
+  created: true
+  status: true
+  uid: true

--- a/config/stevie/core.entity_form_display.paragraph.hours_of_operation.default.yml
+++ b/config/stevie/core.entity_form_display.paragraph.hours_of_operation.default.yml
@@ -1,0 +1,52 @@
+uuid: 57629d09-2ddd-4507-8b82-da5af8f8b157
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.hours_of_operation.field_res_hours
+    - field.field.paragraph.hours_of_operation.field_res_hours_type
+    - field.field.paragraph.hours_of_operation.field_res_is_always_open
+    - paragraphs.paragraphs_type.hours_of_operation
+  module:
+    - paragraphs
+id: paragraph.hours_of_operation.default
+targetEntityType: paragraph
+bundle: hours_of_operation
+mode: default
+content:
+  field_res_hours:
+    type: paragraphs
+    weight: 1
+    region: content
+    settings:
+      title: Paragraph
+      title_plural: Paragraphs
+      edit_mode: closed
+      closed_mode: summary
+      autocollapse: none
+      closed_mode_threshold: 0
+      add_mode: dropdown
+      form_display_mode: default
+      default_paragraph_type: hours_for_day
+      features:
+        duplicate: duplicate
+        collapse_edit_all: collapse_edit_all
+        add_above: '0'
+    third_party_settings: {  }
+  field_res_hours_type:
+    type: options_select
+    weight: 0
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_res_is_always_open:
+    type: boolean_checkbox
+    weight: 2
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+hidden:
+  created: true
+  status: true
+  uid: true

--- a/drush/sites/calendar.site.yml
+++ b/drush/sites/calendar.site.yml
@@ -2,7 +2,7 @@ local:
   host: uwmed.local
   options: {  }
   root: /var/www/uwmed/docroot
-  uri: 'calendar.uwmed.local'
+  uri: calendar.uwmed.local
   user: vagrant
   ssh:
     options: '-o PasswordAuthentication=no -i $HOME/.vagrant.d/insecure_private_key'
@@ -11,19 +11,19 @@ dev:
   options: { ac-env: dev, ac-realm: prod, ac-site: calendar }
   paths: { drush-script: drush9 }
   root: /var/www/html/uwmed.dev/docroot
-  uri: 'calendar.cmsdev.uwmedicine.org'
+  uri: calendar.cmsdev.uwmedicine.org
   user: uwmed.dev
 test:
-  host: uwmedra.ssh.prod.acquia-sites.com
+  host: uwmedstg.ssh.prod.acquia-sites.com
   options: { ac-env: test, ac-realm: prod, ac-site: calendar }
   paths: { drush-script: drush9 }
-  root: /var/www/html/uwmed.ra/docroot
-  uri: 'calendar.cmsstage.uwmedicine.org '
-  user: uwmed.ra
+  root: /var/www/html/uwmed.test/docroot
+  uri: calendar.cmsstage.uwmedicine.org
+  user: uwmed.test
 prod:
   host: uwmed.ssh.prod.acquia-sites.com
   options: { ac-env: prod, ac-realm: prod, ac-site: calendar }
   paths: { drush-script: drush9 }
   root: /var/www/html/uwmed.prod/docroot
-  uri: 'calendar.cms.uwmedicine.org'
+  uri: calendar.cms.uwmedicine.org
   user: uwmed.prod

--- a/drush/sites/huddle.site.yml
+++ b/drush/sites/huddle.site.yml
@@ -2,7 +2,7 @@ local:
   host: uwmed.local
   options: {  }
   root: /var/www/uwmed/docroot
-  uri: 'http://huddle.uwmed.local'
+  uri: huddle.uwmed.local
   user: vagrant
   ssh:
     options: '-o PasswordAuthentication=no -i $HOME/.vagrant.d/insecure_private_key'
@@ -11,19 +11,19 @@ dev:
   options: { ac-env: dev, ac-realm: prod, ac-site: huddle }
   paths: { drush-script: drush9 }
   root: /var/www/html/uwmed.dev/docroot
-  uri: 'huddle.cmsdev.uwmedicine.org'
+  uri: huddle.cmsdev.uwmedicine.org
   user: uwmed.dev
 test:
-  host: uwmedra.ssh.prod.acquia-sites.com
+  host: uwmedstg.ssh.prod.acquia-sites.com
   options: { ac-env: test, ac-realm: prod, ac-site: huddle }
   paths: { drush-script: drush9 }
-  root: /var/www/html/uwmed.ra/docroot
-  uri: 'huddle.cmstest.uwmedicine.org'
-  user: uwmed.ra
+  root: /var/www/html/uwmed.test/docroot
+  uri: huddle.cmsstage.uwmedicine.org
+  user: uwmed.test
 prod:
   host: uwmed.ssh.prod.acquia-sites.com
   options: { ac-env: prod, ac-realm: prod, ac-site: huddle }
   paths: { drush-script: drush9 }
   root: /var/www/html/uwmed.prod/docroot
-  uri: 'huddle.uwmedicine.org'
+  uri: huddle.uwmedicine.org
   user: uwmed.prod


### PR DESCRIPTION
1. Per updating Config Ignore module to 2.2 in #1456:
Change format of `config_ignore.settings` config to use dashed list instead of numerically indexed. This aligns with the change in the module: https://www.drupal.org/project/config_ignore/issues/3002832

2. Updates the Drush aliases for `calendar` and `huddle` sites to point `test` to Acquia stage environment, rather than RA.

3. Removes env splits of `config_ignore.settings` on `stevie` and `default` (CMS) - these were unnecessary, because the same configs are being ignored across environments.