### PR TITLE
maintenance/config-ignore-2.2-settings-format > master

### DIFF
--- a/config/calendar/config_ignore.settings.yml
+++ b/config/calendar/config_ignore.settings.yml
@@ -1,5 +1,5 @@
 ignored_config_entities:
-  0: acquia_lift.settings
-  2: acquia_contenthub.admin_settings
+  - acquia_lift.settings
+  - acquia_contenthub.admin_settings
 _core:
   default_config_hash: UVH1aJ4b44UM-VdPVN7hNNuuVqfReJxwfVeDQH1Hvsk

--- a/config/chew/config_ignore.settings.yml
+++ b/config/chew/config_ignore.settings.yml
@@ -1,5 +1,5 @@
 ignored_config_entities:
-  0: fb_instant_articles.settings
-  2: 'webform.webform.*'
+  - fb_instant_articles.settings
+  - 'webform.webform.*'
 _core:
   default_config_hash: UVH1aJ4b44UM-VdPVN7hNNuuVqfReJxwfVeDQH1Hvsk

--- a/config/contentrepo/config_ignore.settings.yml
+++ b/config/contentrepo/config_ignore.settings.yml
@@ -1,5 +1,5 @@
 ignored_config_entities:
-  0: acquia_connector.settings
-  2: media_acquiadam.settings
+  - acquia_connector.settings
+  - media_acquiadam.settings
 _core:
   default_config_hash: UVH1aJ4b44UM-VdPVN7hNNuuVqfReJxwfVeDQH1Hvsk

--- a/config/default/config_ignore.settings.yml
+++ b/config/default/config_ignore.settings.yml
@@ -4,5 +4,6 @@ ignored_config_entities:
   - devel.toolbar.settings
   - system.menu.devel
   - d8_google_optimize_hide_page.settings
+  - 'webform.webform.*'
 _core:
   default_config_hash: UVH1aJ4b44UM-VdPVN7hNNuuVqfReJxwfVeDQH1Hvsk

--- a/config/default/config_ignore.settings.yml
+++ b/config/default/config_ignore.settings.yml
@@ -1,9 +1,8 @@
 ignored_config_entities:
-  0: acquia_connector.settings
-  2: devel.settings
-  4: devel.toolbar.settings
-  6: system.menu.devel
-  8: d8_google_optimize_hide_page.settings
-  10: 'webform.webform.*'
+  - acquia_connector.settings
+  - devel.settings
+  - devel.toolbar.settings
+  - system.menu.devel
+  - d8_google_optimize_hide_page.settings
 _core:
   default_config_hash: UVH1aJ4b44UM-VdPVN7hNNuuVqfReJxwfVeDQH1Hvsk

--- a/config/default/config_split.config_split.prod.yml
+++ b/config/default/config_split.config_split.prod.yml
@@ -10,7 +10,6 @@ module: {  }
 theme: {  }
 blacklist: {  }
 graylist:
-  - config_ignore.settings
   - d8_google_optimize_hide_page.settings
 graylist_dependents: false
 graylist_skip_equal: true

--- a/config/envs/prod/default/config_ignore.settings.yml
+++ b/config/envs/prod/default/config_ignore.settings.yml
@@ -1,8 +1,0 @@
-ignored_config_entities:
-  0: acquia_connector.settings
-  2: devel.settings
-  4: devel.toolbar.settings
-  6: system.menu.devel
-  7: d8_google_optimize_hide_page.settings
-_core:
-  default_config_hash: UVH1aJ4b44UM-VdPVN7hNNuuVqfReJxwfVeDQH1Hvsk

--- a/config/envs/prod/stevie/config_ignore.settings.yml
+++ b/config/envs/prod/stevie/config_ignore.settings.yml
@@ -1,7 +1,0 @@
-ignored_config_entities:
-  0: acquia_connector.settings
-  1: media_acquiadam.settings
-  2: d8_google_optimize_hide_page.settings
-  3: 'webform.webform.*'
-_core:
-  default_config_hash: UVH1aJ4b44UM-VdPVN7hNNuuVqfReJxwfVeDQH1Hvsk

--- a/config/envs/stage/default/config_ignore.settings.yml
+++ b/config/envs/stage/default/config_ignore.settings.yml
@@ -1,8 +1,0 @@
-ignored_config_entities:
-  0: acquia_connector.settings
-  2: devel.settings
-  4: devel.toolbar.settings
-  6: system.menu.devel
-  7: d8_google_optimize_hide_page.settings
-_core:
-  default_config_hash: UVH1aJ4b44UM-VdPVN7hNNuuVqfReJxwfVeDQH1Hvsk

--- a/config/huddle/config_ignore.settings.yml
+++ b/config/huddle/config_ignore.settings.yml
@@ -1,6 +1,6 @@
 ignored_config_entities:
-  0: acquia_lift.settings
-  2: acquia_contenthub.admin_settings
-  4: 'webform.webform.*'
+  - acquia_lift.settings
+  - acquia_contenthub.admin_settings
+  - 'webform.webform.*'
 _core:
   default_config_hash: UVH1aJ4b44UM-VdPVN7hNNuuVqfReJxwfVeDQH1Hvsk

--- a/config/stevie/config_ignore.settings.yml
+++ b/config/stevie/config_ignore.settings.yml
@@ -1,7 +1,7 @@
 ignored_config_entities:
-  0: acquia_connector.settings
-  1: media_acquiadam.settings
-  2: d8_google_optimize_hide_page.settings
-  3: 'webform.webform.*'
+  - acquia_connector.settings
+  - media_acquiadam.settings
+  - d8_google_optimize_hide_page.settings
+  - 'webform.webform.*'
 _core:
   default_config_hash: UVH1aJ4b44UM-VdPVN7hNNuuVqfReJxwfVeDQH1Hvsk

--- a/config/stevie/config_split.config_split.prod.yml
+++ b/config/stevie/config_split.config_split.prod.yml
@@ -10,7 +10,6 @@ module: {  }
 theme: {  }
 blacklist: {  }
 graylist:
-  - config_ignore.settings
   - d8_google_optimize_hide_page.settings
   - search_api.server.acquia_search_server
 graylist_dependents: false

--- a/drush/sites/calendar.site.yml
+++ b/drush/sites/calendar.site.yml
@@ -2,7 +2,7 @@ local:
   host: uwmed.local
   options: {  }
   root: /var/www/uwmed/docroot
-  uri: 'calendar.uwmed.local'
+  uri: calendar.uwmed.local
   user: vagrant
   ssh:
     options: '-o PasswordAuthentication=no -i $HOME/.vagrant.d/insecure_private_key'
@@ -11,19 +11,19 @@ dev:
   options: { ac-env: dev, ac-realm: prod, ac-site: calendar }
   paths: { drush-script: drush9 }
   root: /var/www/html/uwmed.dev/docroot
-  uri: 'calendar.cmsdev.uwmedicine.org'
+  uri: calendar.cmsdev.uwmedicine.org
   user: uwmed.dev
 test:
-  host: uwmedra.ssh.prod.acquia-sites.com
+  host: uwmedstg.ssh.prod.acquia-sites.com
   options: { ac-env: test, ac-realm: prod, ac-site: calendar }
   paths: { drush-script: drush9 }
-  root: /var/www/html/uwmed.ra/docroot
-  uri: 'calendar.cmsstage.uwmedicine.org '
-  user: uwmed.ra
+  root: /var/www/html/uwmed.test/docroot
+  uri: calendar.cmsstage.uwmedicine.org
+  user: uwmed.test
 prod:
   host: uwmed.ssh.prod.acquia-sites.com
   options: { ac-env: prod, ac-realm: prod, ac-site: calendar }
   paths: { drush-script: drush9 }
   root: /var/www/html/uwmed.prod/docroot
-  uri: 'calendar.cms.uwmedicine.org'
+  uri: calendar.cms.uwmedicine.org
   user: uwmed.prod

--- a/drush/sites/huddle.site.yml
+++ b/drush/sites/huddle.site.yml
@@ -2,7 +2,7 @@ local:
   host: uwmed.local
   options: {  }
   root: /var/www/uwmed/docroot
-  uri: 'http://huddle.uwmed.local'
+  uri: huddle.uwmed.local
   user: vagrant
   ssh:
     options: '-o PasswordAuthentication=no -i $HOME/.vagrant.d/insecure_private_key'
@@ -11,19 +11,19 @@ dev:
   options: { ac-env: dev, ac-realm: prod, ac-site: huddle }
   paths: { drush-script: drush9 }
   root: /var/www/html/uwmed.dev/docroot
-  uri: 'huddle.cmsdev.uwmedicine.org'
+  uri: huddle.cmsdev.uwmedicine.org
   user: uwmed.dev
 test:
-  host: uwmedra.ssh.prod.acquia-sites.com
+  host: uwmedstg.ssh.prod.acquia-sites.com
   options: { ac-env: test, ac-realm: prod, ac-site: huddle }
   paths: { drush-script: drush9 }
-  root: /var/www/html/uwmed.ra/docroot
-  uri: 'huddle.cmstest.uwmedicine.org'
-  user: uwmed.ra
+  root: /var/www/html/uwmed.test/docroot
+  uri: huddle.cmsstage.uwmedicine.org
+  user: uwmed.test
 prod:
   host: uwmed.ssh.prod.acquia-sites.com
   options: { ac-env: prod, ac-realm: prod, ac-site: huddle }
   paths: { drush-script: drush9 }
   root: /var/www/html/uwmed.prod/docroot
-  uri: 'huddle.uwmedicine.org'
+  uri: huddle.uwmedicine.org
   user: uwmed.prod


### PR DESCRIPTION
1. Per updating Config Ignore module to 2.2 in #1456:
Change format of `config_ignore.settings` config to use dashed list instead of numerically indexed. This aligns with the change in the module: https://www.drupal.org/project/config_ignore/issues/3002832

2. Updates the Drush aliases for `calendar` and `huddle` sites to point `test` to Acquia stage environment, rather than RA.

3. Removes env splits of `config_ignore.settings` on `stevie` and `default` (CMS) - these were unnecessary, because the same configs are being ignored across environments.