### PR TITLE
hotfix/temp-disable-appt-fields-migration > master

### DIFF
--- a/config/stevie/migrate_plus.migration.uwm_res_providers_import_providers.yml
+++ b/config/stevie/migrate_plus.migration.uwm_res_providers_import_providers.yml
@@ -204,10 +204,10 @@ process:
   field_res_biography/summary: field_res_biography/summary
   field_res_gender: field_res_gender
   field_res_internal_url: field_res_internal_url
-  field_res_isacceptingnewpts: field_res_isacceptingnewpts
+  # TEMP DISABLE # field_res_isacceptingnewpts: field_res_isacceptingnewpts
   field_res_meta_tags: field_res_meta_tags
-  field_res_ser_id: field_res_ser_id
-  field_res_is_open_scheduling: field_res_is_open_scheduling
+  # TEMP DISABLE # field_res_ser_id: field_res_ser_id
+  # TEMP DISABLE # field_res_is_open_scheduling: field_res_is_open_scheduling
   field_res_is_independent: field_res_is_independent
   field_uwm_json_packet: uwm_json_packet
   field_res_name/title: field_res_name/title


### PR DESCRIPTION
Temporarily disable importing appointment field values on providers Res => Stevie migration, in prep for releasing appointment work:

- field_res_isacceptingnewpts
- field_res_ser_id
- field_res_is_open_scheduling

(Other fields are not yet in the migration:
- field_res_visit_type_id
- field_res_isacceptingreturnpts
- field_res_is_direct_scheduling)