### PR TITLE
hotfix/link-with-icon-paragraph-empty-fatal > stage

### DIFF
--- a/config/stevie/field.field.paragraph.uwm_link_with_icon.field_uwm_link.yml
+++ b/config/stevie/field.field.paragraph.uwm_link_with_icon.field_uwm_link.yml
@@ -13,7 +13,7 @@ entity_type: paragraph
 bundle: uwm_link_with_icon
 label: Link
 description: ''
-required: false
+required: true
 translatable: false
 default_value: {  }
 default_value_callback: ''

--- a/docroot/themes/custom/uwmbase/templates/paragraphs/paragraph--uwm-link-with-icon--uwm-card.html.twig
+++ b/docroot/themes/custom/uwmbase/templates/paragraphs/paragraph--uwm-link-with-icon--uwm-card.html.twig
@@ -4,23 +4,33 @@
 {% set link_target = elements.field_link.0['#options'].attributes.target %}
 {% set link_target = link_target == "_self" ? "" : link_target %}
 {% set url = content.field_uwm_link.0['#url'] %}
-{% block paragraph %}
-    <{{ element }}{{ attributes.addClass(classes) }} id="ppg-{{ paragraph.id() }}">
-        {% block content %}
-            {% spaceless %}
-{#                <a class="btn btn-default {{ link_classes }}" href="{{ url|render }}" target="{{ link_target }}">#}
-{#                    #}{##}
-{#                      @see field--paragraph--field-uwm-icon.html.twig#}
-{#                      @see field--paragraph--field-uwm-link--uwm-link-with-icon.html.twig#}
-{#                    #}
-{#                    {{ content }}#}
-{#                </a>#}
-              {#                    // @TODO Verify new CTA #}
-              {{ uwm_cta_link(content|render,
-                url|render,
-                [link_classes, 'btn', 'btn-default']) }}
 
-            {% endspaceless %}
-        {% endblock content %}
-    </{{ element }}>
+{% block paragraph %}
+    {% if content.field_uwm_link.0 is not empty %}
+        <{{ element }}{{ attributes.addClass(classes) }} id="ppg-{{ paragraph.id() }}">
+            {% block content %}
+                {% spaceless %}
+
+                    {#
+                        The Link field template renders only the link text, so the
+                        URL is handled separately here.
+                        @see field--paragraph--field-uwm-icon.html.twig
+                        @see field--paragraph--field-uwm-link--uwm-link-with-icon.html.twig
+                    #}
+
+                    {#
+                    <a class="btn btn-default {{ link_classes }}" href="{{ url|render }}" target="{{ link_target }}">
+                        {{ content }}
+                    </a>
+                    #}
+
+                    {# // @TODO Verify new CTA #}
+                    {{ uwm_cta_link(content|render,
+                        url|render,
+                        [link_classes, 'btn', 'btn-default']) }}
+
+                {% endspaceless %}
+            {% endblock content %}
+        </{{ element }}>
+    {% endif %}
 {% endblock paragraph %}

--- a/docroot/themes/custom/uwmbase/templates/paragraphs/paragraph--uwm-link-with-icon.html.twig
+++ b/docroot/themes/custom/uwmbase/templates/paragraphs/paragraph--uwm-link-with-icon.html.twig
@@ -6,18 +6,31 @@
 {% set url = paragraph.field_uwm_link.0.url %}
 
 {% block paragraph %}
-    <{{ element }}{{ attributes.addClass(classes) }} id="ppg-{{ paragraph.id() }}">
-        {% block content %}
-            {% spaceless %}
-{#                <a class="btn btn-default {{ link_classes }}" href="{{ url|render }}" target="{{ link_target }}">#}
-{#                {{ content }}#}
-{#                </a>#}
-              {#                    // @TODO Verify new CTA #}
-              {{ uwm_cta_link(content|render,
-                url|render,
-                [link_classes, 'btn', 'btn-default']) }}
+    {% if content.field_uwm_link.0 is not empty %}
+        <{{ element }}{{ attributes.addClass(classes) }} id="ppg-{{ paragraph.id() }}">
+            {% block content %}
+                {% spaceless %}
 
-            {% endspaceless %}
-        {% endblock content %}
-    </{{ element }}>
+                    {#
+                        The Link field template renders only the link text, so the
+                        URL is handled separately here.
+                        @see field--paragraph--field-uwm-icon.html.twig
+                        @see field--paragraph--field-uwm-link--uwm-link-with-icon.html.twig
+                    #}
+
+                    {#
+                    <a class="btn btn-default {{ link_classes }}" href="{{ url|render }}" target="{{ link_target }}">    
+                        {{ content }}
+                    </a>
+                    #}
+
+                    {# // @TODO Verify new CTA #}
+                    {{ uwm_cta_link(content|render,
+                        url|render,
+                        [link_classes, 'btn', 'btn-default']) }}
+
+                {% endspaceless %}
+            {% endblock content %}
+        </{{ element }}>
+    {% endif %}
 {% endblock paragraph %}


### PR DESCRIPTION
Fixes this fatal error:

```
TypeError: Argument 2 passed to Drupal\uwmcs_extension\TwigExtension::getCustomLinkRenderArray() must be of the type string, null given, called in /mnt/tmp/uwmed/php_storage/twig/d995f99/stevie/twig/5e3b2ff6367f8_paragraph--uwm-link-with-_ezfiZm7FNwDJdrdg-yYbxfbca/sA9rBoR3hal06ycCWV0YuEMXHiDAwdHhzqKjHSSELBI.php
```

which occurred when a Link with Icon paragraph was present, but its Link field was left empty. The template had assumed the link field would be populated and ended up passing a NULL value for the URL to the `uwm_cta_link()` twig function.

Also sets the Link field on the paragraph type to be required, since it does not make sense to have a Link with Icon paragraph without the link.