### PR TITLE
hotfix/config-update-clinic-displays > master

### DIFF
--- a/config/stevie/core.entity_view_display.node.res_clinic.card.yml
+++ b/config/stevie/core.entity_view_display.node.res_clinic.card.yml
@@ -40,9 +40,12 @@ dependencies:
     - field.field.node.res_clinic.field_res_providers
     - field.field.node.res_clinic.field_res_room_number
     - field.field.node.res_clinic.field_search_best_bets
+    - field.field.node.res_clinic.field_uwm_banner_content
+    - field.field.node.res_clinic.field_uwm_content_owner
     - field.field.node.res_clinic.field_uwm_json_packet
     - field.field.node.res_clinic.field_uwm_sections
     - field.field.node.res_clinic.field_uwm_sections_2
+    - field.field.node.res_clinic.field_uwm_subject_matter_experts
     - field.field.node.res_clinic.uwm_unique_id
     - node.type.res_clinic
     - responsive_image.styles.clinic_card
@@ -153,6 +156,7 @@ hidden:
   field_search_best_bets: true
   field_test_m_services2: true
   field_test_m_services3: true
+  field_uwm_banner_content: true
   field_uwm_content_owner: true
   field_uwm_json_packet: true
   field_uwm_sections: true

--- a/config/stevie/core.entity_view_display.node.res_clinic.search_result.yml
+++ b/config/stevie/core.entity_view_display.node.res_clinic.search_result.yml
@@ -40,9 +40,12 @@ dependencies:
     - field.field.node.res_clinic.field_res_providers
     - field.field.node.res_clinic.field_res_room_number
     - field.field.node.res_clinic.field_search_best_bets
+    - field.field.node.res_clinic.field_uwm_banner_content
+    - field.field.node.res_clinic.field_uwm_content_owner
     - field.field.node.res_clinic.field_uwm_json_packet
     - field.field.node.res_clinic.field_uwm_sections
     - field.field.node.res_clinic.field_uwm_sections_2
+    - field.field.node.res_clinic.field_uwm_subject_matter_experts
     - field.field.node.res_clinic.uwm_unique_id
     - node.type.res_clinic
   module:
@@ -100,6 +103,7 @@ hidden:
   field_search_best_bets: true
   field_test_m_services2: true
   field_test_m_services3: true
+  field_uwm_banner_content: true
   field_uwm_content_owner: true
   field_uwm_json_packet: true
   field_uwm_sections: true

--- a/config/stevie/core.entity_view_display.node.res_clinic.teaser.yml
+++ b/config/stevie/core.entity_view_display.node.res_clinic.teaser.yml
@@ -40,9 +40,12 @@ dependencies:
     - field.field.node.res_clinic.field_res_providers
     - field.field.node.res_clinic.field_res_room_number
     - field.field.node.res_clinic.field_search_best_bets
+    - field.field.node.res_clinic.field_uwm_banner_content
+    - field.field.node.res_clinic.field_uwm_content_owner
     - field.field.node.res_clinic.field_uwm_json_packet
     - field.field.node.res_clinic.field_uwm_sections
     - field.field.node.res_clinic.field_uwm_sections_2
+    - field.field.node.res_clinic.field_uwm_subject_matter_experts
     - field.field.node.res_clinic.uwm_unique_id
     - node.type.res_clinic
   module:
@@ -100,6 +103,7 @@ hidden:
   field_search_best_bets: true
   field_test_m_services2: true
   field_test_m_services3: true
+  field_uwm_banner_content: true
   field_uwm_content_owner: true
   field_uwm_json_packet: true
   field_uwm_sections: true

--- a/config/stevie/search_api.index.uwm_general_search_api_index.yml
+++ b/config/stevie/search_api.index.uwm_general_search_api_index.yml
@@ -413,4 +413,3 @@ options:
   cron_limit: 50
   overridden_by_acquia_search: 2
 server: acquia_search_server
-

--- a/config/stevie/search_api.index.uwm_locations_geo_search_api_index.yml
+++ b/config/stevie/search_api.index.uwm_locations_geo_search_api_index.yml
@@ -625,4 +625,3 @@ options:
   cron_limit: 50
   overridden_by_acquia_search: 2
 server: acquia_search_server
-


### PR DESCRIPTION
* add missing `field_uwm_banner_content` as hidden on clinic displays
* add missing dependencies on `field_uwm_content_owner`, `field_uwm_subject_matter_experts` on clinic displays
* remove extra blank line at end of two of the search index configs, as it kept coming up as a change in local config exports