### PR TITLE
hotfix/open-sched-widget-remove-mobile-fullscreen-toggle > master

### DIFF
--- a/docroot/themes/custom/uwmbase/components/appointment-flow/uwm-ecare-open-schedule-embedded-widget.js
+++ b/docroot/themes/custom/uwmbase/components/appointment-flow/uwm-ecare-open-schedule-embedded-widget.js
@@ -2,8 +2,9 @@
  * @file
  * JS provided by Epic to initialize the eCare open scheduling embedded widget.
  *
- * The denoted section within this code is not written by UWM; should not be
- * modified unless per communication with Epic team.
+ * The denoted section within this code is not written by UWM; it should not be
+ * modified (except configuration values) unless per communication with Epic
+ * team.
  *
  * Library: uwmbase/ecare-open-schedule-embedded-widget.
  *
@@ -32,11 +33,19 @@
           // Replace with the hostname of your Open Scheduling site.
           'hostname': 'https://ecare.uwmedicine.org',
 
-          // Must equal media query in EpicWP.css + any left/right margin of the host page. Should also change in EmbeddedWidget.css.
+          // Must equal media query in EpicWP.css + any left/right margin of the
+          // host page. Should also change in EmbeddedWidget.css.
           'matchMediaString': '(max-width: 747px)',
 
-          // Show a button on top of the widget that lets the user see the slots in fullscreen.
-          'showToggleBtn': true,
+          // Show a button on top of the widget that lets the user see the slots
+          // in fullscreen.
+          // Note, 2020-02-12:
+          // This setting is supposed to control whether the button is added,
+          // but currently the setting is not properly read if its value is
+          // `false`.
+          // @see EmbeddedWidgetController.js:
+          // `settings.showToggleBtn ? this._showToggleBtn = settings.showToggleBtn : this._showToggleBtn = true;`.
+          'showToggleBtn': false,
 
           // The toggle button's help text for screen reader.
           'toggleBtnExpandHelpText': 'Expand to see the slots in fullscreen',

--- a/docroot/themes/custom/uwmbase/components/modal/modal-appointment.scss
+++ b/docroot/themes/custom/uwmbase/components/modal/modal-appointment.scss
@@ -266,6 +266,17 @@ body.is-page-node-type-res-clinic .modal-backdrop {
           // ---------------------------------------------------------------
         }
 
+        // For mobile, EmbeddedWidgetController.js injects this element which
+        // is intended to allow the user to toggle the embedded widget's layout
+        // to cover the full screen. However, that does not cooperate with our
+        // modal, instead making the widget iframe cover the rest of the modal
+        // and preventing access to the close button and "Back" link.
+        // Since this element is added to our page which is embedding the iframe
+        // (not within the iframe content), our css can access it.
+        a#toggleBtn {
+          display: none !important;
+        }
+
       }
 
     }


### PR DESCRIPTION
css-hide the button added by EmbeddedWidgetController.js meant to toggle the open scheduling widget to full-screen in mobile - it does not work correctly within our modal