### PR TITLE
hotfix/open-sched-widget-ios-scrolling > stage

### DIFF
--- a/docroot/themes/custom/uwmbase/components/modal/modal-appointment.js
+++ b/docroot/themes/custom/uwmbase/components/modal/modal-appointment.js
@@ -27,14 +27,14 @@
         // that anyway.
         if (/iPhone|iPad/.test(navigator.platform)) {
 
-          // Match e.g. '...OS 12...' or '...OS 13...'.
+          // Extract the major iOS version. Example `navigator.appVersion`:
+          // `5.0 (iPhone; CPU iPhone OS 12_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0 Mobile/15E148 Safari/604.1`.
           var versionMatch = navigator.appVersion.match(/OS (\d+)/);
 
           if (versionMatch && versionMatch[1]) {
             var versionMajor = parseInt(versionMatch[1], 10);
 
             if (!isNaN(versionMajor) && versionMajor < 13) {
-              alert('iOS 12-');
               return true;
             }
           }
@@ -103,8 +103,10 @@
       // Determine whether to link out to the open scheduling widget, instead of
       // embedding it in the iframe.
       // On iPhone/iPad running iOS versions 12 and below, iframes are maximized
-      // and do not scroll, so do not use it because without scrolling, the user
-      // cannot access additional appointment time slots.
+      // and do not scroll, so do not use the open scheduling widget embedded in
+      // an iframe - because without scrolling, the user cannot trigger
+      // additional appointment time slots to load or access whatever might be
+      // cut off at the bottom of each widget step.
       // @see https://bugs.webkit.org/show_bug.cgi?id=149264
       var openSchedulingLinkOut = detectIOS12down();
 

--- a/docroot/themes/custom/uwmbase/components/modal/modal-appointment.js
+++ b/docroot/themes/custom/uwmbase/components/modal/modal-appointment.js
@@ -23,21 +23,26 @@
        */
       function detectIOS12down() {
 
-        // Note: for iPad iOS 13+ this is not 'iPad', but we're not looking for
-        // that anyway.
-        if (/iPhone|iPad/.test(navigator.platform)) {
+        if (typeof navigator !== 'undefined' && typeof navigator.platform === 'string' && typeof navigator.appVersion === 'string') {
 
-          // Extract the major iOS version. Example `navigator.appVersion`:
-          // `5.0 (iPhone; CPU iPhone OS 12_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0 Mobile/15E148 Safari/604.1`.
-          var versionMatch = navigator.appVersion.match(/OS (\d+)/);
+          // Note: for iPad on iOS 13+ this value is not 'iPad', but we're not
+          // looking for that case anyway.
+          if (/iPhone|iPad/.test(navigator.platform)) {
 
-          if (versionMatch && versionMatch[1]) {
-            var versionMajor = parseInt(versionMatch[1], 10);
+            // Extract the major iOS version. Example `navigator.appVersion`:
+            // `5.0 (iPhone; CPU iPhone OS 12_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0 Mobile/15E148 Safari/604.1`.
+            var versionMatch = navigator.appVersion.match(/OS (\d+)/);
 
-            if (!isNaN(versionMajor) && versionMajor < 13) {
-              return true;
+            if (versionMatch && versionMatch[1]) {
+              var versionMajor = parseInt(versionMatch[1], 10);
+
+              if (!isNaN(versionMajor) && versionMajor < 13) {
+                return true;
+              }
             }
+
           }
+
         }
 
         return false;

--- a/docroot/themes/custom/uwmbase/components/modal/modal-appointment.js
+++ b/docroot/themes/custom/uwmbase/components/modal/modal-appointment.js
@@ -18,6 +18,32 @@
         return;
       }
 
+      /*
+       * Detect if device is iPhone or iPad running iOS version 12 or below.
+       */
+      function detectIOS12down() {
+
+        // Note: for iPad iOS 13+ this is not 'iPad', but we're not looking for
+        // that anyway.
+        if (/iPhone|iPad/.test(navigator.platform)) {
+
+          // Match e.g. '...OS 12...' or '...OS 13...'.
+          var versionMatch = navigator.appVersion.match(/OS (\d+)/);
+
+          if (versionMatch && versionMatch[1]) {
+            var versionMajor = parseInt(versionMatch[1], 10);
+
+            if (!isNaN(versionMajor) && versionMajor < 13) {
+              alert('iOS 12-');
+              return true;
+            }
+          }
+        }
+
+        return false;
+
+      }
+
       // The context is the type of page on which the appointment modal is being
       // used. If we're on a provider's bio page, any elements with provider-
       // specific data (e.g. the Epic ID) can stay static throughout modal
@@ -76,7 +102,11 @@
 
       // Determine whether to link out to the open scheduling widget, instead of
       // embedding it in the iframe.
-      var openSchedulingLinkOut = true;
+      // On iPhone/iPad running iOS versions 12 and below, iframes are maximized
+      // and do not scroll, so do not use it because without scrolling, the user
+      // cannot access additional appointment time slots.
+      // @see https://bugs.webkit.org/show_bug.cgi?id=149264
+      var openSchedulingLinkOut = detectIOS12down();
 
       if (openSchedulingLinkOut) {
 


### PR DESCRIPTION
https://www.wrike.com/open.htm?id=464317056

iPhone and iPad on iOS 12 and below do not scroll iframe content. This prevents the user from being able to fully interact with the open scheduling widget in iframe.

As a workaround, detect these devices in JS and when moving to the open scheduling widget, redirect to the widget url, rather than staying on our page with the widget in the iframe.