### PR TITLE
hotfix/hide-content-owner-sme-fields > master

### DIFF
--- a/config/stevie/core.entity_view_display.node.res_provider.autocomplete.yml
+++ b/config/stevie/core.entity_view_display.node.res_provider.autocomplete.yml
@@ -41,6 +41,8 @@ dependencies:
     - field.field.node.res_provider.field_res_visit_type_id
     - field.field.node.res_provider.field_search_best_bets
     - field.field.node.res_provider.field_uwm_content_owner
+    - field.field.node.res_provider.field_uwm_edw_boardcerts
+    - field.field.node.res_provider.field_uwm_edw_education
     - field.field.node.res_provider.field_uwm_json_packet
     - field.field.node.res_provider.field_uwm_subject_matter_experts
     - field.field.node.res_provider.uwm_unique_id

--- a/config/stevie/core.entity_view_display.node.res_provider.card.yml
+++ b/config/stevie/core.entity_view_display.node.res_provider.card.yml
@@ -41,6 +41,8 @@ dependencies:
     - field.field.node.res_provider.field_res_visit_type_id
     - field.field.node.res_provider.field_search_best_bets
     - field.field.node.res_provider.field_uwm_content_owner
+    - field.field.node.res_provider.field_uwm_edw_boardcerts
+    - field.field.node.res_provider.field_uwm_edw_education
     - field.field.node.res_provider.field_uwm_json_packet
     - field.field.node.res_provider.field_uwm_subject_matter_experts
     - field.field.node.res_provider.uwm_unique_id

--- a/config/stevie/core.entity_view_display.node.res_provider.default.yml
+++ b/config/stevie/core.entity_view_display.node.res_provider.default.yml
@@ -78,14 +78,14 @@ content:
     type: name_default
     region: content
   field_ratings:
-    weight: 33
+    weight: 31
     label: above
     settings: {  }
     third_party_settings: {  }
     type: basic_string
     region: content
   field_res_academic_title:
-    weight: 31
+    weight: 29
     label: above
     settings:
       link: true
@@ -229,7 +229,7 @@ content:
     type: entity_reference_label
     region: content
   field_res_medical_title:
-    weight: 28
+    weight: 27
     label: above
     settings:
       link: true
@@ -271,7 +271,7 @@ content:
       prefix_suffix: true
     third_party_settings: {  }
   field_res_patients_treated:
-    weight: 32
+    weight: 30
     label: above
     settings:
       link: true
@@ -294,7 +294,7 @@ content:
       link: true
     third_party_settings: {  }
   field_res_provider_type:
-    weight: 30
+    weight: 28
     label: above
     settings:
       link: true
@@ -335,22 +335,6 @@ content:
     settings:
       link: true
     third_party_settings: {  }
-  field_uwm_content_owner:
-    weight: 27
-    label: above
-    settings:
-      link: true
-    third_party_settings: {  }
-    type: entity_reference_label
-    region: content
-  field_uwm_subject_matter_experts:
-    weight: 29
-    label: above
-    settings:
-      link: true
-    third_party_settings: {  }
-    type: entity_reference_label
-    region: content
   links:
     weight: 14
     region: content
@@ -371,7 +355,9 @@ hidden:
   field_res_meta_tags: true
   field_res_pubmed_ids: true
   field_res_puma_id: true
+  field_uwm_content_owner: true
   field_uwm_edw_boardcerts: true
   field_uwm_edw_education: true
   field_uwm_json_packet: true
+  field_uwm_subject_matter_experts: true
   search_api_excerpt: true

--- a/config/stevie/core.entity_view_display.node.res_provider.provider_card.yml
+++ b/config/stevie/core.entity_view_display.node.res_provider.provider_card.yml
@@ -41,6 +41,8 @@ dependencies:
     - field.field.node.res_provider.field_res_visit_type_id
     - field.field.node.res_provider.field_search_best_bets
     - field.field.node.res_provider.field_uwm_content_owner
+    - field.field.node.res_provider.field_uwm_edw_boardcerts
+    - field.field.node.res_provider.field_uwm_edw_education
     - field.field.node.res_provider.field_uwm_json_packet
     - field.field.node.res_provider.field_uwm_subject_matter_experts
     - field.field.node.res_provider.uwm_unique_id

--- a/config/stevie/core.entity_view_display.node.res_provider.search_result.yml
+++ b/config/stevie/core.entity_view_display.node.res_provider.search_result.yml
@@ -41,6 +41,8 @@ dependencies:
     - field.field.node.res_provider.field_res_visit_type_id
     - field.field.node.res_provider.field_search_best_bets
     - field.field.node.res_provider.field_uwm_content_owner
+    - field.field.node.res_provider.field_uwm_edw_boardcerts
+    - field.field.node.res_provider.field_uwm_edw_education
     - field.field.node.res_provider.field_uwm_json_packet
     - field.field.node.res_provider.field_uwm_subject_matter_experts
     - field.field.node.res_provider.uwm_unique_id

--- a/config/stevie/core.entity_view_display.node.res_provider.teaser.yml
+++ b/config/stevie/core.entity_view_display.node.res_provider.teaser.yml
@@ -41,6 +41,8 @@ dependencies:
     - field.field.node.res_provider.field_res_visit_type_id
     - field.field.node.res_provider.field_search_best_bets
     - field.field.node.res_provider.field_uwm_content_owner
+    - field.field.node.res_provider.field_uwm_edw_boardcerts
+    - field.field.node.res_provider.field_uwm_edw_education
     - field.field.node.res_provider.field_uwm_json_packet
     - field.field.node.res_provider.field_uwm_subject_matter_experts
     - field.field.node.res_provider.uwm_unique_id

--- a/config/stevie/core.entity_view_display.node.uwm_homepage.default.yml
+++ b/config/stevie/core.entity_view_display.node.uwm_homepage.default.yml
@@ -24,14 +24,6 @@ content:
     third_party_settings: {  }
     type: metatag_empty_formatter
     region: content
-  field_uwm_content_owner:
-    weight: 2
-    label: above
-    settings:
-      link: true
-    third_party_settings: {  }
-    type: entity_reference_label
-    region: content
   field_uwm_homepage_markup:
     weight: 0
     label: hidden
@@ -39,15 +31,9 @@ content:
     third_party_settings: {  }
     type: text_default
     region: content
-  field_uwm_subject_matter_experts:
-    weight: 3
-    label: above
-    settings:
-      link: true
-    third_party_settings: {  }
-    type: entity_reference_label
-    region: content
 hidden:
   content_moderation_control: true
+  field_uwm_content_owner: true
+  field_uwm_subject_matter_experts: true
   links: true
   search_api_excerpt: true

--- a/config/stevie/core.entity_view_display.node.uwm_homepage.search_result.yml
+++ b/config/stevie/core.entity_view_display.node.uwm_homepage.search_result.yml
@@ -4,6 +4,10 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.node.search_result
+    - field.field.node.uwm_homepage.field_meta_tags
+    - field.field.node.uwm_homepage.field_uwm_content_owner
+    - field.field.node.uwm_homepage.field_uwm_homepage_markup
+    - field.field.node.uwm_homepage.field_uwm_subject_matter_experts
     - node.type.uwm_homepage
   module:
     - user
@@ -19,3 +23,8 @@ content:
     third_party_settings: {  }
 hidden:
   content_moderation_control: true
+  field_meta_tags: true
+  field_uwm_content_owner: true
+  field_uwm_homepage_markup: true
+  field_uwm_subject_matter_experts: true
+  search_api_excerpt: true

--- a/config/stevie/core.entity_view_display.node.uwm_homepage.teaser.yml
+++ b/config/stevie/core.entity_view_display.node.uwm_homepage.teaser.yml
@@ -4,6 +4,10 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.node.teaser
+    - field.field.node.uwm_homepage.field_meta_tags
+    - field.field.node.uwm_homepage.field_uwm_content_owner
+    - field.field.node.uwm_homepage.field_uwm_homepage_markup
+    - field.field.node.uwm_homepage.field_uwm_subject_matter_experts
     - node.type.uwm_homepage
   module:
     - user
@@ -14,8 +18,13 @@ mode: teaser
 content:
   links:
     weight: 100
+    region: content
     settings: {  }
     third_party_settings: {  }
-    region: content
 hidden:
   content_moderation_control: true
+  field_meta_tags: true
+  field_uwm_content_owner: true
+  field_uwm_homepage_markup: true
+  field_uwm_subject_matter_experts: true
+  search_api_excerpt: true

--- a/config/stevie/core.entity_view_display.node.uwm_hub_page.default.yml
+++ b/config/stevie/core.entity_view_display.node.uwm_hub_page.default.yml
@@ -37,14 +37,6 @@ content:
     third_party_settings: {  }
     type: entity_reference_label
     region: content
-  field_uwm_content_owner:
-    weight: 6
-    label: above
-    settings:
-      link: true
-    third_party_settings: {  }
-    type: entity_reference_label
-    region: content
   field_uwm_hero:
     weight: 0
     label: hidden
@@ -79,16 +71,10 @@ content:
     third_party_settings: {  }
     type: entity_reference_revisions_entity_view
     region: content
-  field_uwm_subject_matter_experts:
-    weight: 7
-    label: above
-    settings:
-      link: true
-    third_party_settings: {  }
-    type: entity_reference_label
-    region: content
 hidden:
   content_moderation_control: true
   field_search_best_bets: true
+  field_uwm_content_owner: true
+  field_uwm_subject_matter_experts: true
   links: true
   search_api_excerpt: true

--- a/config/stevie/core.entity_view_display.node.uwm_hub_page.search_result.yml
+++ b/config/stevie/core.entity_view_display.node.uwm_hub_page.search_result.yml
@@ -5,11 +5,14 @@ dependencies:
   config:
     - core.entity_view_mode.node.search_result
     - field.field.node.uwm_hub_page.field_meta_tags
+    - field.field.node.uwm_hub_page.field_search_best_bets
     - field.field.node.uwm_hub_page.field_uwm_accent_color
+    - field.field.node.uwm_hub_page.field_uwm_content_owner
     - field.field.node.uwm_hub_page.field_uwm_hero
     - field.field.node.uwm_hub_page.field_uwm_page_path_name
     - field.field.node.uwm_hub_page.field_uwm_parent_page
     - field.field.node.uwm_hub_page.field_uwm_sections
+    - field.field.node.uwm_hub_page.field_uwm_subject_matter_experts
     - node.type.uwm_hub_page
   module:
     - entity_reference_revisions
@@ -53,5 +56,9 @@ content:
 hidden:
   content_moderation_control: true
   field_meta_tags: true
+  field_search_best_bets: true
   field_uwm_accent_color: true
+  field_uwm_content_owner: true
   field_uwm_page_path_name: true
+  field_uwm_subject_matter_experts: true
+  search_api_excerpt: true

--- a/config/stevie/core.entity_view_display.node.uwm_medical_service.default.yml
+++ b/config/stevie/core.entity_view_display.node.uwm_medical_service.default.yml
@@ -26,22 +26,14 @@ bundle: uwm_medical_service
 mode: default
 content:
   field_meta_tags:
-    weight: 2
+    weight: 1
     label: hidden
     settings: {  }
     third_party_settings: {  }
     type: metatag_empty_formatter
     region: content
-  field_uwm_content_owner:
-    weight: 3
-    label: above
-    settings:
-      link: true
-    third_party_settings: {  }
-    type: entity_reference_label
-    region: content
   field_uwm_sections:
-    weight: 1
+    weight: 0
     label: hidden
     settings:
       view_mode: default
@@ -49,23 +41,17 @@ content:
     third_party_settings: {  }
     type: entity_reference_revisions_entity_view
     region: content
-  field_uwm_subject_matter_experts:
-    weight: 4
-    label: above
-    settings:
-      link: true
-    third_party_settings: {  }
-    type: entity_reference_label
-    region: content
 hidden:
   content_moderation_control: true
   field_res_conditions_symptoms: true
   field_res_procedures_treatments: true
   field_search_best_bets: true
+  field_uwm_content_owner: true
   field_uwm_find_a_location_link: true
   field_uwm_find_a_provider_link: true
   field_uwm_image: true
   field_uwm_medical_service: true
   field_uwm_page_path_name: true
+  field_uwm_subject_matter_experts: true
   links: true
   search_api_excerpt: true

--- a/config/stevie/core.entity_view_display.node.uwm_medical_service.full.yml
+++ b/config/stevie/core.entity_view_display.node.uwm_medical_service.full.yml
@@ -8,12 +8,14 @@ dependencies:
     - field.field.node.uwm_medical_service.field_res_conditions_symptoms
     - field.field.node.uwm_medical_service.field_res_procedures_treatments
     - field.field.node.uwm_medical_service.field_search_best_bets
+    - field.field.node.uwm_medical_service.field_uwm_content_owner
     - field.field.node.uwm_medical_service.field_uwm_find_a_location_link
     - field.field.node.uwm_medical_service.field_uwm_find_a_provider_link
     - field.field.node.uwm_medical_service.field_uwm_image
     - field.field.node.uwm_medical_service.field_uwm_medical_service
     - field.field.node.uwm_medical_service.field_uwm_page_path_name
     - field.field.node.uwm_medical_service.field_uwm_sections
+    - field.field.node.uwm_medical_service.field_uwm_subject_matter_experts
     - node.type.uwm_medical_service
   module:
     - entity_reference_revisions
@@ -45,10 +47,12 @@ hidden:
   field_res_conditions_symptoms: true
   field_res_procedures_treatments: true
   field_search_best_bets: true
+  field_uwm_content_owner: true
   field_uwm_find_a_location_link: true
   field_uwm_find_a_provider_link: true
   field_uwm_image: true
   field_uwm_medical_service: true
   field_uwm_page_path_name: true
+  field_uwm_subject_matter_experts: true
   links: true
   search_api_excerpt: true

--- a/config/stevie/core.entity_view_display.node.uwm_medical_service.search_result.yml
+++ b/config/stevie/core.entity_view_display.node.uwm_medical_service.search_result.yml
@@ -8,12 +8,14 @@ dependencies:
     - field.field.node.uwm_medical_service.field_res_conditions_symptoms
     - field.field.node.uwm_medical_service.field_res_procedures_treatments
     - field.field.node.uwm_medical_service.field_search_best_bets
+    - field.field.node.uwm_medical_service.field_uwm_content_owner
     - field.field.node.uwm_medical_service.field_uwm_find_a_location_link
     - field.field.node.uwm_medical_service.field_uwm_find_a_provider_link
     - field.field.node.uwm_medical_service.field_uwm_image
     - field.field.node.uwm_medical_service.field_uwm_medical_service
     - field.field.node.uwm_medical_service.field_uwm_page_path_name
     - field.field.node.uwm_medical_service.field_uwm_sections
+    - field.field.node.uwm_medical_service.field_uwm_subject_matter_experts
     - node.type.uwm_medical_service
   module:
     - entity_reference_revisions
@@ -46,9 +48,11 @@ hidden:
   field_res_conditions_symptoms: true
   field_res_procedures_treatments: true
   field_search_best_bets: true
+  field_uwm_content_owner: true
   field_uwm_find_a_location_link: true
   field_uwm_find_a_provider_link: true
   field_uwm_image: true
   field_uwm_page_path_name: true
+  field_uwm_subject_matter_experts: true
   links: true
   search_api_excerpt: true

--- a/config/stevie/core.entity_view_display.node.uwm_medical_service.teaser.yml
+++ b/config/stevie/core.entity_view_display.node.uwm_medical_service.teaser.yml
@@ -8,12 +8,14 @@ dependencies:
     - field.field.node.uwm_medical_service.field_res_conditions_symptoms
     - field.field.node.uwm_medical_service.field_res_procedures_treatments
     - field.field.node.uwm_medical_service.field_search_best_bets
+    - field.field.node.uwm_medical_service.field_uwm_content_owner
     - field.field.node.uwm_medical_service.field_uwm_find_a_location_link
     - field.field.node.uwm_medical_service.field_uwm_find_a_provider_link
     - field.field.node.uwm_medical_service.field_uwm_image
     - field.field.node.uwm_medical_service.field_uwm_medical_service
     - field.field.node.uwm_medical_service.field_uwm_page_path_name
     - field.field.node.uwm_medical_service.field_uwm_sections
+    - field.field.node.uwm_medical_service.field_uwm_subject_matter_experts
     - node.type.uwm_medical_service
   module:
     - user
@@ -33,10 +35,12 @@ hidden:
   field_res_conditions_symptoms: true
   field_res_procedures_treatments: true
   field_search_best_bets: true
+  field_uwm_content_owner: true
   field_uwm_find_a_location_link: true
   field_uwm_find_a_provider_link: true
   field_uwm_image: true
   field_uwm_medical_service: true
   field_uwm_page_path_name: true
   field_uwm_sections: true
+  field_uwm_subject_matter_experts: true
   search_api_excerpt: true

--- a/config/stevie/core.entity_view_display.node.uwm_medical_specialty.default.yml
+++ b/config/stevie/core.entity_view_display.node.uwm_medical_specialty.default.yml
@@ -34,14 +34,6 @@ content:
     label: hidden
     settings: {  }
     third_party_settings: {  }
-  field_uwm_content_owner:
-    weight: 2
-    label: above
-    settings:
-      link: true
-    third_party_settings: {  }
-    type: entity_reference_label
-    region: content
   field_uwm_sections:
     weight: 0
     label: hidden
@@ -51,25 +43,19 @@ content:
     third_party_settings: {  }
     type: entity_reference_revisions_entity_view
     region: content
-  field_uwm_subject_matter_experts:
-    weight: 3
-    label: above
-    settings:
-      link: true
-    third_party_settings: {  }
-    type: entity_reference_label
-    region: content
 hidden:
   body: true
   content_moderation_control: true
   field_res_conditions_symptoms: true
   field_res_procedures_treatments: true
   field_search_best_bets: true
+  field_uwm_content_owner: true
   field_uwm_find_a_location_link: true
   field_uwm_find_a_provider_link: true
   field_uwm_image: true
   field_uwm_page_path_name: true
   field_uwm_parent_page: true
+  field_uwm_subject_matter_experts: true
   field_uwm_weight: true
   links: true
   search_api_excerpt: true

--- a/config/stevie/core.entity_view_display.node.uwm_medical_specialty.full.yml
+++ b/config/stevie/core.entity_view_display.node.uwm_medical_specialty.full.yml
@@ -9,12 +9,14 @@ dependencies:
     - field.field.node.uwm_medical_specialty.field_res_conditions_symptoms
     - field.field.node.uwm_medical_specialty.field_res_procedures_treatments
     - field.field.node.uwm_medical_specialty.field_search_best_bets
+    - field.field.node.uwm_medical_specialty.field_uwm_content_owner
     - field.field.node.uwm_medical_specialty.field_uwm_find_a_location_link
     - field.field.node.uwm_medical_specialty.field_uwm_find_a_provider_link
     - field.field.node.uwm_medical_specialty.field_uwm_image
     - field.field.node.uwm_medical_specialty.field_uwm_page_path_name
     - field.field.node.uwm_medical_specialty.field_uwm_parent_page
     - field.field.node.uwm_medical_specialty.field_uwm_sections
+    - field.field.node.uwm_medical_specialty.field_uwm_subject_matter_experts
     - field.field.node.uwm_medical_specialty.field_uwm_weight
     - node.type.uwm_medical_specialty
   module:
@@ -48,11 +50,13 @@ hidden:
   field_res_conditions_symptoms: true
   field_res_procedures_treatments: true
   field_search_best_bets: true
+  field_uwm_content_owner: true
   field_uwm_find_a_location_link: true
   field_uwm_find_a_provider_link: true
   field_uwm_image: true
   field_uwm_page_path_name: true
   field_uwm_parent_page: true
+  field_uwm_subject_matter_experts: true
   field_uwm_weight: true
   links: true
   search_api_excerpt: true

--- a/config/stevie/core.entity_view_display.node.uwm_medical_specialty.teaser.yml
+++ b/config/stevie/core.entity_view_display.node.uwm_medical_specialty.teaser.yml
@@ -9,12 +9,14 @@ dependencies:
     - field.field.node.uwm_medical_specialty.field_res_conditions_symptoms
     - field.field.node.uwm_medical_specialty.field_res_procedures_treatments
     - field.field.node.uwm_medical_specialty.field_search_best_bets
+    - field.field.node.uwm_medical_specialty.field_uwm_content_owner
     - field.field.node.uwm_medical_specialty.field_uwm_find_a_location_link
     - field.field.node.uwm_medical_specialty.field_uwm_find_a_provider_link
     - field.field.node.uwm_medical_specialty.field_uwm_image
     - field.field.node.uwm_medical_specialty.field_uwm_page_path_name
     - field.field.node.uwm_medical_specialty.field_uwm_parent_page
     - field.field.node.uwm_medical_specialty.field_uwm_sections
+    - field.field.node.uwm_medical_specialty.field_uwm_subject_matter_experts
     - field.field.node.uwm_medical_specialty.field_uwm_weight
     - node.type.uwm_medical_specialty
   module:
@@ -36,10 +38,13 @@ hidden:
   field_res_conditions_symptoms: true
   field_res_procedures_treatments: true
   field_search_best_bets: true
+  field_uwm_content_owner: true
   field_uwm_find_a_location_link: true
   field_uwm_find_a_provider_link: true
   field_uwm_image: true
   field_uwm_page_path_name: true
   field_uwm_parent_page: true
   field_uwm_sections: true
+  field_uwm_subject_matter_experts: true
   field_uwm_weight: true
+  search_api_excerpt: true

--- a/config/stevie/core.entity_view_display.node.uwm_quiz.default.yml
+++ b/config/stevie/core.entity_view_display.node.uwm_quiz.default.yml
@@ -23,27 +23,19 @@ content:
   body:
     label: hidden
     type: text_default
-    weight: 101
+    weight: 1
     settings: {  }
     third_party_settings: {  }
     region: content
-  field_uwm_content_owner:
-    weight: 105
-    label: above
-    settings:
-      link: true
-    third_party_settings: {  }
-    type: entity_reference_label
-    region: content
   field_uwm_formatted_text:
-    weight: 103
+    weight: 3
     label: above
     settings: {  }
     third_party_settings: {  }
     type: text_default
     region: content
   field_uwm_image:
-    weight: 102
+    weight: 2
     label: above
     settings:
       image_style: ''
@@ -52,7 +44,7 @@ content:
     type: image
     region: content
   field_uwm_sections:
-    weight: 104
+    weight: 4
     label: above
     settings:
       view_mode: default
@@ -60,19 +52,13 @@ content:
     third_party_settings: {  }
     type: entity_reference_revisions_entity_view
     region: content
-  field_uwm_subject_matter_experts:
-    weight: 106
-    label: above
-    settings:
-      link: true
-    third_party_settings: {  }
-    type: entity_reference_label
-    region: content
   links:
-    weight: 100
+    weight: 0
+    region: content
     settings: {  }
     third_party_settings: {  }
-    region: content
 hidden:
   content_moderation_control: true
+  field_uwm_content_owner: true
+  field_uwm_subject_matter_experts: true
   search_api_excerpt: true

--- a/config/stevie/core.entity_view_display.node.uwm_quiz.teaser.yml
+++ b/config/stevie/core.entity_view_display.node.uwm_quiz.teaser.yml
@@ -5,9 +5,11 @@ dependencies:
   config:
     - core.entity_view_mode.node.teaser
     - field.field.node.uwm_quiz.body
+    - field.field.node.uwm_quiz.field_uwm_content_owner
     - field.field.node.uwm_quiz.field_uwm_formatted_text
     - field.field.node.uwm_quiz.field_uwm_image
     - field.field.node.uwm_quiz.field_uwm_sections
+    - field.field.node.uwm_quiz.field_uwm_subject_matter_experts
     - node.type.uwm_quiz
   module:
     - text
@@ -27,11 +29,14 @@ content:
     region: content
   links:
     weight: 100
+    region: content
     settings: {  }
     third_party_settings: {  }
-    region: content
 hidden:
   content_moderation_control: true
+  field_uwm_content_owner: true
   field_uwm_formatted_text: true
   field_uwm_image: true
   field_uwm_sections: true
+  field_uwm_subject_matter_experts: true
+  search_api_excerpt: true


### PR DESCRIPTION
- ensure Content Owner and Subject Matter Experts fields are hidden on all content type displays
- misc missing field dependencies and hidden fields on displays